### PR TITLE
Introduce concept of elements as distinct from components

### DIFF
--- a/.vendor.txt
+++ b/.vendor.txt
@@ -3,6 +3,7 @@
     ./_vendor/src/golang.org/x/crypto                        3cb07270c9455e8ad27956a70891c962d121a228  https://go.googlesource.com/crypto
     ./_vendor/src/golang.org/x/tools                         620ecdb8d7943e20dc030b61bfe898d1b000bdea  https://go.googlesource.com/tools
     ./_vendor/src/github.com/gopherjs/gopherjs               9659c814f1d54d63f9c623449a7111d3864c1361  git@github.com:gopherjs/gopherjs
+    ./_vendor/src/github.com/gopherjs/jsbuiltin              67703bfb044e3192fbcab025c3aeaeedafad1f2f  git@github.com:gopherjs/jsbuiltin
     ./_vendor/src/github.com/kisielk/gotool                  0de1eaf82fa3f583ce21fde859f1e7e0c5e9b220  git@github.com:kisielk/gotool
     ./_vendor/src/github.com/fsnotify/fsnotify               7d7316ed6e1ed2de075aab8dfc76de5d158d66e1  git@github.com:fsnotify/fsnotify
     ./_vendor/src/github.com/spf13/cobra                     16c014f1a19d865b765b420e74508f80eb831ada  git@github.com:spf13/cobra

--- a/_vendor/src/github.com/gopherjs/jsbuiltin/.travis.yml
+++ b/_vendor/src/github.com/gopherjs/jsbuiltin/.travis.yml
@@ -1,0 +1,12 @@
+language: go
+go:
+  - 1.8.x
+addons:
+  apt:
+    packages:
+      - nodejs
+install:
+  - go get -u github.com/gopherjs/gopherjs
+script:
+  - diff -u <(echo -n) <(gofmt -d ./)
+  - gopherjs test

--- a/_vendor/src/github.com/gopherjs/jsbuiltin/LICENSE
+++ b/_vendor/src/github.com/gopherjs/jsbuiltin/LICENSE
@@ -1,0 +1,24 @@
+Copyright (c) 2015 Richard Musiol. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/_vendor/src/github.com/gopherjs/jsbuiltin/README.md
+++ b/_vendor/src/github.com/gopherjs/jsbuiltin/README.md
@@ -1,0 +1,103 @@
+[![Build Status](https://api.travis-ci.org/gopherjs/jsbuiltin.svg?branch=master)](https://travis-ci.org/gopherjs/jsbuiltin) [![GoDoc](https://godoc.org/github.com/gopherjs/jsbuiltin?status.png)](http://godoc.org/github.com/gopherjs/jsbuiltin)
+
+jsbuiltin - Built-in JavaScript functions for GopherJS
+------------------------------------------------------
+
+JavaScript has a small number of [built-in
+functions](https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects)
+to handle some common day-to-day tasks. This package providers wrappers around
+some of these functions for use in GopherJS.
+
+It is worth noting that in many cases, using Go's equivalent functionality
+(such as that found in the [net/url](https://golang.org/pkg/net/url/) package)
+may be preferable to using this package, and will be a necessity any time you
+wish to share functionality between front-end and back-end code.
+
+### What is supported?
+Not all JavaScript built-in functions make sense or are useful in a Go
+environment. The table below shows each of the JavaScript built-in functions,
+and its current state in this package.
+
+| Name                 | Supported | Comment                     |
+|----------------------|-----------|-----------------------------|
+| eval()               | --        |                             |
+| uneval()             | --        |                             |
+| isFinite()           | yes       |                             |
+| isNaN()              | yes       |                             |
+| parseFloat()         | TODO?     | See note below              |
+| parseInt()           | TODO?     | See note below              |
+| decodeURI()          | yes       |                             |
+| decodeURIComponent() | yes       |                             |
+| encodeURI()          | yes       |                             |
+| encodeURIComponent() | yes       |                             |
+| escape()             | --        | deprecated circa 2000       |
+| Number()             | --        | See note below              |
+| String()             | --        | Use js.Object.String()      |
+| unescape()           | --        | deprecated circa 2000       |
+| typeof operator      | yes       |                             |
+| instanceof operator  | yes       |                             |
+
+#### Notes on unmplemented functions
+
+* **eval()**: Is there ever a need to eval JS code from within Go?
+* **Number()**: This requires handling a bunch of corner cases which don't
+ normally exist in a strictly typed language such as Go. It seems that anyone
+ with a legitimate need for this function probably needs to write their own
+ wrapper to handle the cases that matter to them.
+* **parseInt()** and **parseFloat()**: These could be added, but doing so
+ will require answering some questions about the interfce. JavaScript has
+ effectively two relevant data types (int and float) where Go has has 12.
+ Deciding how to map JS's `parseInt()` to Go's `(u?)int(8|16|32|64)` types,
+ and JS's `parseFloat()` Go's `float(32|64)` or `complex(64|128)` needs to
+ be considered, as well as how to handle error cases (Go doesn't have a `NaN`
+ type, so any `NaN` result probably needs to be converted to a proper Go
+ error). If this matters to you, comments and/or PRs are welcome.
+
+### Installation and Usage
+Get or update this package and dependencies with:
+
+```
+go get -u -d -tags=js github.com/gopherjs/jsbuiltin
+```
+
+### Basic usage example
+
+This is a modified version of the Pet example in the main GopherJS documentation,
+to accept and return URI-encoded pet names using the jsbuiltin package.
+
+```go
+package main
+
+import (
+	"github.com/gopherjs/gopherjs/js"
+	"github.com/gopherjs/jsbuiltin"
+)
+
+func main() {
+	js.Global.Set("pet", map[string]interface{}{
+		"New": New,
+	})
+}
+
+type Pet struct {
+	name string
+}
+
+func New(name string) *js.Object {
+	return js.MakeWrapper(&Pet{name})
+}
+
+func (p *Pet) Name() string {
+	return jsbuiltin.EncodeURIComponent(p.name)
+}
+
+func (p *Pet) SetName(uriComponent string) error {
+	name, err := jsbuiltin.DecodeURIComponent(uriComponent)
+	if err != nil {
+		// Malformed UTF8 in uriComponent
+		return err
+	}
+	p.name = name
+	return nil
+}
+```

--- a/_vendor/src/github.com/gopherjs/jsbuiltin/jsbuiltin.go
+++ b/_vendor/src/github.com/gopherjs/jsbuiltin/jsbuiltin.go
@@ -1,0 +1,98 @@
+// Package jsbuiltin provides minimal wrappers around some JavasScript
+// built-in functions.
+package jsbuiltin
+
+import (
+	"errors"
+
+	"github.com/gopherjs/gopherjs/js"
+)
+
+// DecodeURI decodes a Uniform Resource Identifier (URI) previously created
+// by EncodeURI() or by a similar routine. If the underlying JavaScript
+// function throws an error, it is returned as an error.
+func DecodeURI(uri string) (raw string, err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			err = r.(*js.Error)
+		}
+	}()
+	raw = js.Global.Call("decodeURI", uri).String()
+	return
+}
+
+// EncodeURI encodes a Uniform Resource Identifier (URI) by replacing each
+// instance of certain characters by one, two, three, or four escape sequences
+// representing the UTF-8 encoding of the character (will only be four escape
+// sequences for characters composed of two "surrogate" characters).
+func EncodeURI(uri string) string {
+	return js.Global.Call("encodeURI", uri).String()
+}
+
+// EncodeURIComponent encodes a Uniform Resource Identifier (URI) component
+// by replacing each instance of certain characters by one, two, three, or
+// four escape sequences representing the UTF-8 encoding of the character
+// (will only be four escape sequences for characters composed of two
+// "surrogate" characters).
+func EncodeURIComponent(uri string) string {
+	return js.Global.Call("encodeURIComponent", uri).String()
+}
+
+// DecodeURIComponent decodes a Uniform Resource Identifier (URI) component
+// previously created by EncodeURIComponent() or by a similar routine. If the
+// underlying JavaScript function throws an error, it is returned as an error.
+func DecodeURIComponent(uri string) (raw string, err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			err = r.(*js.Error)
+		}
+	}()
+	raw = js.Global.Call("decodeURIComponent", uri).String()
+	return
+}
+
+// IsFinite determines whether the passed value is a finite number, and returns
+// true if it is. If needed, the parameter is first converted to a number.
+func IsFinite(value interface{}) bool {
+	return js.Global.Call("isFinite", value).Bool()
+}
+
+// IsNaN determines whether a value is NaN (Not-a-Number) or not. A return
+// value of true indicates the input value is considered NaN by JavaScript.
+func IsNaN(value interface{}) bool {
+	return js.Global.Call("isNaN", value).Bool()
+}
+
+// Type constants represent the JavaScript builtin types, which may be returned
+// by TypeOf().
+const (
+	TypeUndefined = "undefined"
+	TypeNull      = "null"
+	TypeObject    = "object"
+	TypeBoolean   = "boolean"
+	TypeNumber    = "number"
+	TypeString    = "string"
+	TypeFunction  = "function"
+	TypeSymbol    = "symbol"
+)
+
+// TypeOf returns the JavaScript type of the passed value
+func TypeOf(value interface{}) string {
+	return js.Global.Get("$jsbuiltin$").Call("typeoffunc", value).String()
+}
+
+// InstanceOf returns true if value is an instance of object according to the
+// built-in 'instanceof' operator. `object` must be a *js.Object representing
+// a javascript constructor function.
+func InstanceOf(value interface{}, object *js.Object) bool {
+	return js.Global.Get("$jsbuiltin$").Call("instanceoffunc", value, object).Bool()
+}
+
+// In returns true if key is a member of obj. An error is returned if obj is not
+// a JavaScript object.
+func In(key string, obj *js.Object) (ok bool, err error) {
+	if obj == nil || obj == js.Undefined || TypeOf(obj) != TypeObject {
+		return false, errors.New("obj not a JavaScript object")
+	}
+	return js.Global.Get("$jsbuiltin$").Call("infunc", key, obj).Bool(), nil
+}

--- a/_vendor/src/github.com/gopherjs/jsbuiltin/jsbuiltin.inc.js
+++ b/_vendor/src/github.com/gopherjs/jsbuiltin/jsbuiltin.inc.js
@@ -1,0 +1,5 @@
+$global.$jsbuiltin$ = {
+    typeoffunc: function(x) { return typeof x },
+    instanceoffunc: function(x,y) { return x instanceof y },
+    infunc: function(x,y) { return x in y }
+}

--- a/_vendor/src/github.com/gopherjs/jsbuiltin/jsbuiltin_test.go
+++ b/_vendor/src/github.com/gopherjs/jsbuiltin/jsbuiltin_test.go
@@ -1,0 +1,233 @@
+// +build js
+
+package jsbuiltin
+
+import (
+	"testing"
+
+	"github.com/gopherjs/gopherjs/js"
+)
+
+func TestEncodeURI(t *testing.T) {
+	data := map[string]string{
+		"http://foo.com/?msg=Привет мир.": "http://foo.com/?msg=%D0%9F%D1%80%D0%B8%D0%B2%D0%B5%D1%82%20%D0%BC%D0%B8%D1%80.",
+		"http://user:host@foo.com/":       "http://user:host@foo.com/",
+	}
+	for url, expected := range data {
+		result := EncodeURI(url)
+		if result != expected {
+			t.Fatalf("EncodeURI(%s) returned '%s', not '%s'", url, result, expected)
+		}
+	}
+}
+
+type testData struct {
+	URL           string
+	ExpectedURL   string
+	ExpectedError string
+}
+
+func TestDecodeURI(t *testing.T) {
+	data := []testData{
+		testData{
+			"http://foo.com/?msg=%D0%9F%D1%80%D0%B8%D0%B2%D0%B5%D1%82%20%D0%BC%D0%B8%D1%80.", "http://foo.com/?msg=Привет мир.", "",
+		},
+		testData{
+			"http://user:host@foo.com/", "http://user:host@foo.com/", "",
+		},
+		testData{
+			"http://foo.com/?invalidutf8=%80", "", "JavaScript error: URI malformed",
+		},
+	}
+	for _, test := range data {
+		result, err := DecodeURI(test.URL)
+		if test.ExpectedError != "" {
+			if err == nil {
+				t.Fatalf("DecodeURI(%s) should have resulted in an error", test.URL)
+			}
+			if err.Error() != test.ExpectedError {
+				t.Fatalf("DecodeURI(%s) should have resulted in error '%s', got '%s'", test.URL, test.ExpectedError, err)
+			}
+		} else {
+			if err != nil {
+				t.Fatalf("DecodeURI() resulted in an error: %s", err)
+			}
+			if result != test.ExpectedURL {
+				t.Fatalf("DecodeURI(%s) returned '%s', not '%s'", test.URL, result, test.ExpectedURL)
+			}
+		}
+	}
+}
+
+func TestEncodeURIComponentn(t *testing.T) {
+	data := map[string]string{
+		"Привет мир.": "%D0%9F%D1%80%D0%B8%D0%B2%D0%B5%D1%82%20%D0%BC%D0%B8%D1%80.",
+		"bar": "bar",
+	}
+	for url, expected := range data {
+		result := EncodeURIComponent(url)
+		if result != expected {
+			t.Fatalf("EncodeURIComponent(%s) returned '%s', not '%s'", url, result, expected)
+		}
+	}
+}
+
+func TestDecodeURIComponentn(t *testing.T) {
+	data := []testData{
+		testData{
+			"%D0%9F%D1%80%D0%B8%D0%B2%D0%B5%D1%82%20%D0%BC%D0%B8%D1%80.", "Привет мир.", "",
+		},
+		testData{
+			"bar", "bar", "",
+		},
+		testData{
+			"%80", "", "JavaScript error: URI malformed",
+		},
+	}
+	for _, test := range data {
+		result, err := DecodeURIComponent(test.URL)
+		if test.ExpectedError != "" {
+			if err == nil {
+				t.Fatalf("DecodeURIComponent(%s) should have resulted in an error", test.URL)
+			}
+			if err.Error() != test.ExpectedError {
+				t.Fatalf("DecodeURIComponent(%s) should have resulted in error '%s', got '%s'", test.URL, test.ExpectedError, err)
+			}
+		} else {
+			if err != nil {
+				t.Fatalf("DecodeURIComponent() resulted in an error: %s", err)
+			}
+			if result != test.ExpectedURL {
+				t.Fatalf("DecodeURIComponent(%s) returned '%s', not '%s'", test.URL, result, test.ExpectedURL)
+			}
+		}
+	}
+}
+
+func TestIsFinite(t *testing.T) {
+	data := map[interface{}]bool{
+		123:          true,
+		-1.23:        true,
+		5 - 2:        true,
+		0:            true,
+		"123":        true,
+		"Hello":      false,
+		"2005/12/12": false,
+	}
+	for value, expected := range data {
+		result := IsFinite(value)
+		if result != expected {
+			t.Fatalf("IsFinite(%s) returned %t, not %t", value, result, expected)
+		}
+	}
+}
+
+func TestIsNaN(t *testing.T) {
+	data := map[interface{}]bool{
+		123:          false,
+		-1.23:        false,
+		5 - 2:        false,
+		0:            false,
+		"123":        false,
+		"Hello":      true,
+		"2005/12/12": true,
+	}
+	for value, expected := range data {
+		result := IsNaN(value)
+		if result != expected {
+			t.Fatalf("IsNaN(%s) returned %t, not %t", value, result, expected)
+		}
+	}
+}
+
+type toTest struct {
+	value  interface{}
+	result string
+}
+
+func TestTypeOf(t *testing.T) {
+	data := []toTest{
+		// Standard JS types
+		toTest{js.Undefined, "undefined"},
+		toTest{nil, "object"},
+		toTest{true, "boolean"},
+		toTest{false, "boolean"},
+		toTest{12345, "number"},
+		toTest{"one two three", "string"},
+		toTest{js.Global.Call, "function"},
+		toTest{js.Global, "object"},
+	}
+	// Check whether the JS interpretor supports the 'symbol' type (Node >= 0.12)
+	if TypeOf(js.Global.Get("Symbol")) == "function" {
+		symbol := js.Global.Call("Symbol", "foo")
+		data = append(data, toTest{&symbol, "symbol"})
+	}
+	for _, test := range data {
+		result := TypeOf(test.value)
+		if result != test.result {
+			t.Fatalf("Typeof(%s) returned %s, not %s", test.value, result, test.result)
+		}
+	}
+
+	if to := TypeOf(map[string]string{}); to != "object" {
+		t.Fatalf("Obscure type not recognized as object")
+	}
+	if to := TypeOf(js.Object{}); to != "object" {
+		t.Fatal("Invalid/empty JS object not recognized as object")
+	}
+}
+
+type ioTest struct {
+	value  interface{}
+	object *js.Object
+	result bool
+}
+
+func TestInstanceOf(t *testing.T) {
+	data := []ioTest{
+		// Standard JS types
+		ioTest{js.Undefined, js.Global.Get("Object"), false},
+		ioTest{"a string", js.Global.Get("String"), false},
+		ioTest{js.Global.Get("String").New("foo"), js.Global.Get("String"), true},
+		ioTest{js.Global.Get("String").New("foo"), js.Global.Get("Object"), true},
+	}
+	for _, test := range data {
+		result := InstanceOf(test.value, test.object)
+		if result != test.result {
+			t.Errorf("InstanceOf(%s,%s) returned %t, not %t", test.value, test.object, result, test.result)
+		}
+	}
+}
+
+type inTest struct {
+	obj    *js.Object
+	key    string
+	result bool
+	err    string
+}
+
+func TestIn(t *testing.T) {
+	obj := js.Global.Get("Object").New()
+	obj.Set("foo", "bar")
+	jsString := js.Global.Call("eval", `'"test string"'`)
+	data := []inTest{
+		{obj: obj, key: "foo", result: true},
+		{obj: obj, key: "bar", result: false},
+		{obj: js.Undefined, key: "foo", err: "obj not a JavaScript function"},
+		{obj: nil, key: "foo", err: "obj not a JavaScript function"},
+		{obj: jsString, key: "foo", err: "obj not a JavaScript function"},
+	}
+	for _, test := range data {
+		result, err := In(test.key, test.obj)
+		var msg string
+		if err != nil {
+			msg = err.Error()
+		}
+		if msg != test.err {
+			t.Errorf("Unexpected error: %s", msg)
+		}
+		if result != test.result {
+			t.Errorf("In(%v, %s) returned %t, not %t", test.obj, test.key, result, test.result)
+		}
+	}
+}

--- a/a.go
+++ b/a.go
@@ -3,11 +3,9 @@
 
 package react
 
-import "github.com/gopherjs/gopherjs/js"
-
-// ADef is the React component definition corresponding to the HTML <a> element
-type ADef struct {
-	underlying *js.Object
+// AElem is the React element definition corresponding to the HTML <a> element
+type AElem struct {
+	Element
 }
 
 // _APropsDef defines the properties for the <a> element
@@ -18,11 +16,9 @@ type _AProps struct {
 	Href   string `js:"href"`
 }
 
-func (d *ADef) reactElement() {}
-
 // A creates a new instance of a <a> element with the provided props and
 // children
-func A(props *AProps, children ...Element) *ADef {
+func A(props *AProps, children ...Element) *AElem {
 
 	rProps := &_AProps{
 		BasicHTMLElement: newBasicHTMLElement(),
@@ -40,5 +36,5 @@ func A(props *AProps, children ...Element) *ADef {
 
 	underlying := react.Call("createElement", args...)
 
-	return &ADef{underlying: underlying}
+	return &AElem{Element: elementHolder{elem: underlying}}
 }

--- a/br.go
+++ b/br.go
@@ -3,11 +3,9 @@
 
 package react
 
-import "github.com/gopherjs/gopherjs/js"
-
-// BRDef is the React component definition corresponding to the HTML <br> element
-type BRDef struct {
-	underlying *js.Object
+// BRElem is the React element definition corresponding to the HTML <br> element
+type BRElem struct {
+	Element
 }
 
 // _BRProps defines the properties for the <br> element
@@ -15,10 +13,8 @@ type _BRProps struct {
 	*BasicHTMLElement
 }
 
-func (d *BRDef) reactElement() {}
-
 // BR creates a new instance of a <br> element with the provided props
-func BR(props *BRProps) *BRDef {
+func BR(props *BRProps) *BRElem {
 
 	rProps := &_BRProps{
 		BasicHTMLElement: newBasicHTMLElement(),
@@ -30,5 +26,5 @@ func BR(props *BRProps) *BRDef {
 
 	underlying := react.Call("createElement", "br", rProps)
 
-	return &BRDef{underlying: underlying}
+	return &BRElem{Element: elementHolder{elem: underlying}}
 }

--- a/button.go
+++ b/button.go
@@ -3,11 +3,9 @@
 
 package react
 
-import "github.com/gopherjs/gopherjs/js"
-
-// ButtonDef is the React component definition corresponding to the HTML <button> element
-type ButtonDef struct {
-	underlying *js.Object
+// ButtonElem is the React element definition corresponding to the HTML <button> element
+type ButtonElem struct {
+	Element
 }
 
 // _ButtonProps defines the properties for the <button> element
@@ -17,11 +15,9 @@ type _ButtonProps struct {
 	Type string `js:"type"`
 }
 
-func (d *ButtonDef) reactElement() {}
-
 // Button creates a new instance of a <button> element with the provided props
 // and child
-func Button(props *ButtonProps, children ...Element) *ButtonDef {
+func Button(props *ButtonProps, children ...Element) *ButtonElem {
 
 	rProps := &_ButtonProps{
 		BasicHTMLElement: newBasicHTMLElement(),
@@ -39,7 +35,5 @@ func Button(props *ButtonProps, children ...Element) *ButtonDef {
 
 	underlying := react.Call("createElement", args...)
 
-	return &ButtonDef{
-		underlying: underlying,
-	}
+	return &ButtonElem{Element: elementHolder{elem: underlying}}
 }

--- a/cmd/reactGen/gen.go
+++ b/cmd/reactGen/gen.go
@@ -153,7 +153,7 @@ func dogen(dir, license string) {
 						}
 						g.pointMeths[id.Name] = append(g.pointMeths[id.Name], funcFile{d, file})
 					case *ast.Ident:
-						g.nonPointMeths[v.Name] = append(g.pointMeths[v.Name], funcFile{d, file})
+						g.nonPointMeths[v.Name] = append(g.nonPointMeths[v.Name], funcFile{d, file})
 					}
 
 				case *ast.GenDecl:

--- a/cmd/reactGen/init.go
+++ b/cmd/reactGen/init.go
@@ -83,13 +83,11 @@ type AppDef struct {
 	r.ComponentDef
 }
 
-func App() *AppDef {
-	res := new(AppDef)
-	r.BlessElement(res, nil)
-	return res
+func App() *AppElem {
+	return &AppElem{Element: r.CreateElement(buildApp, nil)}
 }
 
-func (a *AppDef) Render() r.Element {
+func (a AppDef) Render() r.Element {
 	return r.Div(nil,
 		r.H1(nil,
 			r.S("Hello World"),

--- a/code.go
+++ b/code.go
@@ -3,11 +3,9 @@
 
 package react
 
-import "github.com/gopherjs/gopherjs/js"
-
-// CodeDef is the React component definition corresponding to the HTML <code> element
-type CodeDef struct {
-	underlying *js.Object
+// CodeElem is the React element definition corresponding to the HTML <code> element
+type CodeElem struct {
+	Element
 }
 
 // _CodeProps defines the properties for the <code> element
@@ -15,10 +13,8 @@ type _CodeProps struct {
 	*BasicHTMLElement
 }
 
-func (d *CodeDef) reactElement() {}
-
 // Code creates a new instance of a <code> element with the provided props
-func Code(props *CodeProps, children ...Element) *CodeDef {
+func Code(props *CodeProps, children ...Element) *CodeElem {
 
 	rProps := &_CodeProps{
 		BasicHTMLElement: newBasicHTMLElement(),
@@ -36,5 +32,5 @@ func Code(props *CodeProps, children ...Element) *CodeDef {
 
 	underlying := react.Call("createElement", args...)
 
-	return &CodeDef{underlying: underlying}
+	return &CodeElem{Element: elementHolder{elem: underlying}}
 }

--- a/components/imm/gen_Select_reactGen.go
+++ b/components/imm/gen_Select_reactGen.go
@@ -4,7 +4,11 @@ package imm
 
 import "myitcv.io/react"
 
-func (s *SelectDef) ShouldComponentUpdateIntf(nextProps, prevState, nextState interface{}) bool {
+type SelectElem struct {
+	react.Element
+}
+
+func (s SelectDef) ShouldComponentUpdateIntf(nextProps, prevState, nextState interface{}) bool {
 	res := false
 
 	{
@@ -15,16 +19,20 @@ func (s *SelectDef) ShouldComponentUpdateIntf(nextProps, prevState, nextState in
 	return res
 }
 
+func buildSelect(cd react.ComponentDef) react.Component {
+	return SelectDef{ComponentDef: cd}
+}
+
 // SetState is an auto-generated proxy proxy to update the state for the
 // Select component.  SetState does not immediately mutate s.State()
 // but creates a pending state transition.
-func (s *SelectDef) SetState(state SelectState) {
+func (s SelectDef) SetState(state SelectState) {
 	s.ComponentDef.SetState(state)
 }
 
 // State is an auto-generated proxy to return the current state in use for the
 // render of the Select component
-func (s *SelectDef) State() SelectState {
+func (s SelectDef) State() SelectState {
 	return s.ComponentDef.State().(SelectState)
 }
 
@@ -35,7 +43,7 @@ func (s SelectState) IsState() {}
 var _ react.State = SelectState{}
 
 // GetInitialStateIntf is an auto-generated proxy to GetInitialState
-func (s *SelectDef) GetInitialStateIntf() react.State {
+func (s SelectDef) GetInitialStateIntf() react.State {
 	return SelectState{}
 }
 
@@ -44,14 +52,14 @@ func (s SelectState) EqualsIntf(val interface{}) bool {
 }
 
 // Props is an auto-generated proxy to the current props of Select
-func (s *SelectDef) Props() SelectProps {
+func (s SelectDef) Props() SelectProps {
 	uprops := s.ComponentDef.Props()
 	return uprops.(SelectProps)
 }
 
 // ComponentWillReceivePropsIntf is an auto-generated proxy to
 // ComponentWillReceiveProps
-func (s *SelectDef) ComponentWillReceivePropsIntf(val interface{}) {
+func (s SelectDef) ComponentWillReceivePropsIntf(val interface{}) {
 	ourProps := val.(SelectProps)
 	s.ComponentWillReceiveProps(ourProps)
 }

--- a/components/imm/select.go
+++ b/components/imm/select.go
@@ -60,21 +60,19 @@ type _Imm_entriesKeysSelect []entryKey
 
 // Select creates a new instance of the SelectDef component with the provided props
 //
-func Select(props SelectProps) *SelectDef {
-	res := new(SelectDef)
-	r.BlessElement(res, props)
-	return res
+func Select(props SelectProps) *SelectElem {
+	return &SelectElem{Element: r.CreateElement(buildSelect, props)}
 }
 
-func (p *SelectDef) ComponentWillMount() {
+func (p SelectDef) ComponentWillMount() {
 	p.updateMap(p.Props().Entries)
 }
 
-func (p *SelectDef) ComponentWillReceiveProps(props SelectProps) {
+func (p SelectDef) ComponentWillReceiveProps(props SelectProps) {
 	p.updateMap(props.Entries)
 }
 
-func (p *SelectDef) updateMap(es ImmSelectEntry) {
+func (p SelectDef) updateMap(es ImmSelectEntry) {
 	eks := newEntriesKeysSelect().AsMutable()
 	defer eks.AsImmutable(nil)
 
@@ -98,9 +96,9 @@ func (p *SelectDef) updateMap(es ImmSelectEntry) {
 	p.SetState(st)
 }
 
-func (p *SelectDef) Render() r.Element {
+func (p SelectDef) Render() r.Element {
 
-	var ps []*r.OptionDef
+	var ps []*r.OptionElem
 
 	for _, v := range p.State().entries.Range() {
 		p := r.Option(
@@ -120,7 +118,7 @@ func (p *SelectDef) Render() r.Element {
 	)
 }
 
-type changeEntry struct{ *SelectDef }
+type changeEntry struct{ SelectDef }
 
 func (c changeEntry) OnChange(e *r.SyntheticEvent) {
 	v := e.Target().(*dom.HTMLSelectElement).Value

--- a/core.go
+++ b/core.go
@@ -34,7 +34,7 @@ type BasicHTMLElement struct {
 	OnChange `js:"onChange"`
 	OnClick  `js:"onClick"`
 
-	DangerouslySetInnerHTML *DangerousInnerHTMLDef `js:"dangerouslySetInnerHTML"`
+	DangerouslySetInnerHTML *DangerousInnerHTML `js:"dangerouslySetInnerHTML"`
 }
 
 func newBasicHTMLElement() *BasicHTMLElement {

--- a/dangerous_inner_html.go
+++ b/dangerous_inner_html.go
@@ -5,22 +5,23 @@ package react
 
 import "github.com/gopherjs/gopherjs/js"
 
-// DangerousInnerHTMLDef is convenience component definition that allows HTML to be directly
+// DangerousInnerHTML is convenience definition that allows HTML to be directly
 // set as the child of a DOM element. See
-// https://facebook.github.io/react/docs/dom-elements.html#dangerouslysetinnerhtml for more details
-type DangerousInnerHTMLDef struct {
+// https://facebook.github.io/react/docs/dom-elements.html#dangerouslysetinnerhtml
+// for more details
+type DangerousInnerHTML struct {
 	o *js.Object
 }
 
-// DangerousInnerHTML creates a new instance of a DangerousInnerHTMLDef component, using the
+// NewDangerousInnerHTML creates a new DangerousInnerHTML instance, using the
 // supplied string as the raw HTML
-func DangerousInnerHTML(s string) *DangerousInnerHTMLDef {
+func NewDangerousInnerHTML(s string) *DangerousInnerHTML {
 	o := object.New()
 	o.Set("__html", s)
 
-	res := &DangerousInnerHTMLDef{o: o}
+	res := &DangerousInnerHTML{o: o}
 
 	return res
 }
 
-func (d *DangerousInnerHTMLDef) reactElement() {}
+func (d *DangerousInnerHTML) reactElement() {}

--- a/div.go
+++ b/div.go
@@ -3,11 +3,9 @@
 
 package react
 
-import "github.com/gopherjs/gopherjs/js"
-
-// DivDef is the React component definition corresponding to the HTML <div> element
-type DivDef struct {
-	underlying *js.Object
+// DivElem is the React element definition corresponding to the HTML <div> element
+type DivElem struct {
+	Element
 }
 
 // _DivProps are the props for a <div> component
@@ -15,10 +13,8 @@ type _DivProps struct {
 	*BasicHTMLElement
 }
 
-func (d *DivDef) reactElement() {}
-
 // Div creates a new instance of a <div> element with the provided props and children
-func Div(props *DivProps, children ...Element) *DivDef {
+func Div(props *DivProps, children ...Element) *DivElem {
 
 	rProps := &_DivProps{
 		BasicHTMLElement: newBasicHTMLElement(),
@@ -36,5 +32,5 @@ func Div(props *DivProps, children ...Element) *DivDef {
 
 	underlying := react.Call("createElement", args...)
 
-	return &DivDef{underlying: underlying}
+	return &DivElem{Element: elementHolder{elem: underlying}}
 }

--- a/examples/blog/2017_04_16/app.go
+++ b/examples/blog/2017_04_16/app.go
@@ -10,13 +10,11 @@ type AppDef struct {
 	r.ComponentDef
 }
 
-func App() *AppDef {
-	res := new(AppDef)
-	r.BlessElement(res, nil)
-	return res
+func App() *AppElem {
+	return &AppElem{Element: r.CreateElement(buildApp, nil)}
 }
 
-func (a *AppDef) Render() r.Element {
+func (a AppDef) Render() r.Element {
 	return r.Div(nil,
 		r.H1(nil,
 			r.S("Hello World"),

--- a/examples/blog/2017_04_16/foo_bar.go
+++ b/examples/blog/2017_04_16/foo_bar.go
@@ -39,19 +39,15 @@ type FooBarState struct {
 // FooBar is the constructor for a FooBar component. Given that this component
 // can take props (can, not must), we add a parameter of type *FooBarProps
 //
-func FooBar(p FooBarProps) *FooBarDef {
-	res := new(FooBarDef)
-
+func FooBar(p FooBarProps) *FooBarElem {
 	// every component constructor must call this function
-	r.BlessElement(res, p)
-
-	return res
+	return &FooBarElem{Element: r.CreateElement(buildFooBar, p)}
 }
 
 // Render is a required method on all React components. Notice that the method
 // is declared on a pointer type *FooBarDef.
 //
-func (f *FooBarDef) Render() r.Element {
+func (f FooBarDef) Render() r.Element {
 
 	// all React components must render under a single root. This is typically achieved
 	// by rendering everything within a <div> elememt
@@ -72,7 +68,7 @@ func (f *FooBarDef) Render() r.Element {
 // ageClick implements the react.OnClick interface to handle when the "Bump age" button
 // is clicked
 //
-type ageClick struct{ *FooBarDef }
+type ageClick struct{ FooBarDef }
 
 // OnClick is the ageClick implementation of the react.OnClick interface
 //

--- a/examples/blog/2017_04_16/gen_App_reactGen.go
+++ b/examples/blog/2017_04_16/gen_App_reactGen.go
@@ -2,8 +2,18 @@
 
 package main
 
-func (a *AppDef) ShouldComponentUpdateIntf(nextProps, prevState, nextState interface{}) bool {
+import "myitcv.io/react"
+
+type AppElem struct {
+	react.Element
+}
+
+func (a AppDef) ShouldComponentUpdateIntf(nextProps, prevState, nextState interface{}) bool {
 	res := false
 
 	return res
+}
+
+func buildApp(cd react.ComponentDef) react.Component {
+	return AppDef{ComponentDef: cd}
 }

--- a/examples/blog/2017_04_16/gen_FooBar_reactGen.go
+++ b/examples/blog/2017_04_16/gen_FooBar_reactGen.go
@@ -4,7 +4,11 @@ package main
 
 import "myitcv.io/react"
 
-func (f *FooBarDef) ShouldComponentUpdateIntf(nextProps, prevState, nextState interface{}) bool {
+type FooBarElem struct {
+	react.Element
+}
+
+func (f FooBarDef) ShouldComponentUpdateIntf(nextProps, prevState, nextState interface{}) bool {
 	res := false
 
 	{
@@ -15,16 +19,20 @@ func (f *FooBarDef) ShouldComponentUpdateIntf(nextProps, prevState, nextState in
 	return res
 }
 
+func buildFooBar(cd react.ComponentDef) react.Component {
+	return FooBarDef{ComponentDef: cd}
+}
+
 // SetState is an auto-generated proxy proxy to update the state for the
 // FooBar component.  SetState does not immediately mutate f.State()
 // but creates a pending state transition.
-func (f *FooBarDef) SetState(state FooBarState) {
+func (f FooBarDef) SetState(state FooBarState) {
 	f.ComponentDef.SetState(state)
 }
 
 // State is an auto-generated proxy to return the current state in use for the
 // render of the FooBar component
-func (f *FooBarDef) State() FooBarState {
+func (f FooBarDef) State() FooBarState {
 	return f.ComponentDef.State().(FooBarState)
 }
 
@@ -35,7 +43,7 @@ func (f FooBarState) IsState() {}
 var _ react.State = FooBarState{}
 
 // GetInitialStateIntf is an auto-generated proxy to GetInitialState
-func (f *FooBarDef) GetInitialStateIntf() react.State {
+func (f FooBarDef) GetInitialStateIntf() react.State {
 	return FooBarState{}
 }
 
@@ -44,7 +52,7 @@ func (f FooBarState) EqualsIntf(val interface{}) bool {
 }
 
 // Props is an auto-generated proxy to the current props of FooBar
-func (f *FooBarDef) Props() FooBarProps {
+func (f FooBarDef) Props() FooBarProps {
 	uprops := f.ComponentDef.Props()
 	return uprops.(FooBarProps)
 }

--- a/examples/examples.go
+++ b/examples/examples.go
@@ -30,10 +30,8 @@ const (
 )
 
 // Examples creates instances of the Examples component
-func Examples() *ExamplesDef {
-	res := new(ExamplesDef)
-	r.BlessElement(res, nil)
-	return res
+func Examples() *ExamplesElem {
+	return &ExamplesElem{Element: r.CreateElement(buildExamples, nil)}
 }
 
 type (
@@ -47,7 +45,7 @@ type ExamplesState struct {
 }
 
 // ComponentWillMount is a React lifecycle method for the Examples component
-func (p *ExamplesDef) ComponentWillMount() {
+func (p ExamplesDef) ComponentWillMount() {
 	if !fetchStarted {
 		for i, e := range sources.Range() {
 			go func(i exampleKey, e *source) {
@@ -70,7 +68,7 @@ func (p *ExamplesDef) ComponentWillMount() {
 }
 
 // GetInitialState returns in the initial state for the Examples component
-func (p *ExamplesDef) GetInitialState() ExamplesState {
+func (p ExamplesDef) GetInitialState() ExamplesState {
 	return ExamplesState{
 		examples:     sources,
 		selectedTabs: newTabS(),
@@ -78,7 +76,7 @@ func (p *ExamplesDef) GetInitialState() ExamplesState {
 }
 
 // Render renders the Examples component
-func (p *ExamplesDef) Render() r.Element {
+func (p ExamplesDef) Render() r.Element {
 	dc := jsx.HTML(`
 		<h3>Introduction</h3>
 
@@ -151,7 +149,7 @@ func (p *ExamplesDef) Render() r.Element {
 	)
 }
 
-func (p *ExamplesDef) renderExample(key exampleKey, title, msg r.Element, jsxSrc string, elem r.Element) r.Element {
+func (p ExamplesDef) renderExample(key exampleKey, title, msg r.Element, jsxSrc string, elem r.Element) r.Element {
 
 	var goSrc string
 	src, _ := p.State().examples.Get(key)
@@ -159,12 +157,12 @@ func (p *ExamplesDef) renderExample(key exampleKey, title, msg r.Element, jsxSrc
 		goSrc = src.src()
 	}
 
-	var code *r.DangerousInnerHTMLDef
+	var code *r.DangerousInnerHTML
 	switch v, _ := p.State().selectedTabs.Get(key); v {
 	case tabGo:
-		code = r.DangerousInnerHTML(highlightjs.Highlight("go", goSrc, true).Value)
+		code = r.NewDangerousInnerHTML(highlightjs.Highlight("go", goSrc, true).Value)
 	case tabJsx:
-		code = r.DangerousInnerHTML(highlightjs.Highlight("javascript", jsxSrc, true).Value)
+		code = r.NewDangerousInnerHTML(highlightjs.Highlight("javascript", jsxSrc, true).Value)
 	}
 
 	return r.Div(nil,
@@ -198,7 +196,7 @@ func (p *ExamplesDef) renderExample(key exampleKey, title, msg r.Element, jsxSrc
 	)
 }
 
-func (p *ExamplesDef) buildExampleNavTab(key exampleKey, t tab, title string) *r.LiDef {
+func (p ExamplesDef) buildExampleNavTab(key exampleKey, t tab, title string) *r.LiElem {
 	lip := &r.LiProps{Role: "presentation"}
 
 	if v, _ := p.State().selectedTabs.Get(key); v == t {
@@ -216,7 +214,7 @@ func (p *ExamplesDef) buildExampleNavTab(key exampleKey, t tab, title string) *r
 }
 
 type tabChange struct {
-	e   *ExamplesDef
+	e   ExamplesDef
 	key exampleKey
 	t   tab
 }

--- a/examples/gen_Examples_reactGen.go
+++ b/examples/gen_Examples_reactGen.go
@@ -4,7 +4,11 @@ package examples
 
 import "myitcv.io/react"
 
-func (e *ExamplesDef) ShouldComponentUpdateIntf(nextProps, prevState, nextState interface{}) bool {
+type ExamplesElem struct {
+	react.Element
+}
+
+func (e ExamplesDef) ShouldComponentUpdateIntf(nextProps, prevState, nextState interface{}) bool {
 	res := false
 
 	v := prevState.(ExamplesState)
@@ -12,16 +16,20 @@ func (e *ExamplesDef) ShouldComponentUpdateIntf(nextProps, prevState, nextState 
 	return res
 }
 
+func buildExamples(cd react.ComponentDef) react.Component {
+	return ExamplesDef{ComponentDef: cd}
+}
+
 // SetState is an auto-generated proxy proxy to update the state for the
 // Examples component.  SetState does not immediately mutate e.State()
 // but creates a pending state transition.
-func (e *ExamplesDef) SetState(state ExamplesState) {
+func (e ExamplesDef) SetState(state ExamplesState) {
 	e.ComponentDef.SetState(state)
 }
 
 // State is an auto-generated proxy to return the current state in use for the
 // render of the Examples component
-func (e *ExamplesDef) State() ExamplesState {
+func (e ExamplesDef) State() ExamplesState {
 	return e.ComponentDef.State().(ExamplesState)
 }
 
@@ -32,7 +40,7 @@ func (e ExamplesState) IsState() {}
 var _ react.State = ExamplesState{}
 
 // GetInitialStateIntf is an auto-generated proxy to GetInitialState
-func (e *ExamplesDef) GetInitialStateIntf() react.State {
+func (e ExamplesDef) GetInitialStateIntf() react.State {
 	return e.GetInitialState()
 }
 

--- a/examples/gen_GlobalStateExamples_reactGen.go
+++ b/examples/gen_GlobalStateExamples_reactGen.go
@@ -4,7 +4,11 @@ package examples
 
 import "myitcv.io/react"
 
-func (g *GlobalStateExamplesDef) ShouldComponentUpdateIntf(nextProps, prevState, nextState interface{}) bool {
+type GlobalStateExamplesElem struct {
+	react.Element
+}
+
+func (g GlobalStateExamplesDef) ShouldComponentUpdateIntf(nextProps, prevState, nextState interface{}) bool {
 	res := false
 
 	v := prevState.(GlobalStateExamplesState)
@@ -12,16 +16,20 @@ func (g *GlobalStateExamplesDef) ShouldComponentUpdateIntf(nextProps, prevState,
 	return res
 }
 
+func buildGlobalStateExamples(cd react.ComponentDef) react.Component {
+	return GlobalStateExamplesDef{ComponentDef: cd}
+}
+
 // SetState is an auto-generated proxy proxy to update the state for the
 // GlobalStateExamples component.  SetState does not immediately mutate g.State()
 // but creates a pending state transition.
-func (g *GlobalStateExamplesDef) SetState(state GlobalStateExamplesState) {
+func (g GlobalStateExamplesDef) SetState(state GlobalStateExamplesState) {
 	g.ComponentDef.SetState(state)
 }
 
 // State is an auto-generated proxy to return the current state in use for the
 // render of the GlobalStateExamples component
-func (g *GlobalStateExamplesDef) State() GlobalStateExamplesState {
+func (g GlobalStateExamplesDef) State() GlobalStateExamplesState {
 	return g.ComponentDef.State().(GlobalStateExamplesState)
 }
 
@@ -32,7 +40,7 @@ func (g GlobalStateExamplesState) IsState() {}
 var _ react.State = GlobalStateExamplesState{}
 
 // GetInitialStateIntf is an auto-generated proxy to GetInitialState
-func (g *GlobalStateExamplesDef) GetInitialStateIntf() react.State {
+func (g GlobalStateExamplesDef) GetInitialStateIntf() react.State {
 	return g.GetInitialState()
 }
 

--- a/examples/gen_ImmExamples_reactGen.go
+++ b/examples/gen_ImmExamples_reactGen.go
@@ -4,7 +4,11 @@ package examples
 
 import "myitcv.io/react"
 
-func (i *ImmExamplesDef) ShouldComponentUpdateIntf(nextProps, prevState, nextState interface{}) bool {
+type ImmExamplesElem struct {
+	react.Element
+}
+
+func (i ImmExamplesDef) ShouldComponentUpdateIntf(nextProps, prevState, nextState interface{}) bool {
 	res := false
 
 	v := prevState.(ImmExamplesState)
@@ -12,16 +16,20 @@ func (i *ImmExamplesDef) ShouldComponentUpdateIntf(nextProps, prevState, nextSta
 	return res
 }
 
+func buildImmExamples(cd react.ComponentDef) react.Component {
+	return ImmExamplesDef{ComponentDef: cd}
+}
+
 // SetState is an auto-generated proxy proxy to update the state for the
 // ImmExamples component.  SetState does not immediately mutate i.State()
 // but creates a pending state transition.
-func (i *ImmExamplesDef) SetState(state ImmExamplesState) {
+func (i ImmExamplesDef) SetState(state ImmExamplesState) {
 	i.ComponentDef.SetState(state)
 }
 
 // State is an auto-generated proxy to return the current state in use for the
 // render of the ImmExamples component
-func (i *ImmExamplesDef) State() ImmExamplesState {
+func (i ImmExamplesDef) State() ImmExamplesState {
 	return i.ComponentDef.State().(ImmExamplesState)
 }
 
@@ -32,7 +40,7 @@ func (i ImmExamplesState) IsState() {}
 var _ react.State = ImmExamplesState{}
 
 // GetInitialStateIntf is an auto-generated proxy to GetInitialState
-func (i *ImmExamplesDef) GetInitialStateIntf() react.State {
+func (i ImmExamplesDef) GetInitialStateIntf() react.State {
 	return i.GetInitialState()
 }
 

--- a/examples/global_state_examples.go
+++ b/examples/global_state_examples.go
@@ -11,10 +11,8 @@ type GlobalStateExamplesDef struct {
 }
 
 // GlobalStateExamples creates instances of the GlobalStateExamples component
-func GlobalStateExamples() *GlobalStateExamplesDef {
-	res := new(GlobalStateExamplesDef)
-	r.BlessElement(res, nil)
-	return res
+func GlobalStateExamples() *GlobalStateExamplesElem {
+	return &GlobalStateExamplesElem{Element: r.CreateElement(buildGlobalStateExamples, nil)}
 }
 
 // GlobalStateExamplesState is the state type for the GlobalStateExamples component
@@ -24,7 +22,7 @@ type GlobalStateExamplesState struct {
 }
 
 // ComponentWillMount is a React lifecycle method for the GlobalStateExamples component
-func (p *GlobalStateExamplesDef) ComponentWillMount() {
+func (p GlobalStateExamplesDef) ComponentWillMount() {
 	if !fetchStarted {
 		for i, e := range sources.Range() {
 			go func(i exampleKey, e *source) {
@@ -47,7 +45,7 @@ func (p *GlobalStateExamplesDef) ComponentWillMount() {
 }
 
 // GetInitialState returns in the initial state for the GlobalStateExamples component
-func (p *GlobalStateExamplesDef) GetInitialState() GlobalStateExamplesState {
+func (p GlobalStateExamplesDef) GetInitialState() GlobalStateExamplesState {
 	return GlobalStateExamplesState{
 		examples:     sources,
 		selectedTabs: newTabS(),
@@ -55,10 +53,10 @@ func (p *GlobalStateExamplesDef) GetInitialState() GlobalStateExamplesState {
 }
 
 // Render renders the GlobalStateExamples component
-func (p *GlobalStateExamplesDef) Render() r.Element {
+func (p GlobalStateExamplesDef) Render() r.Element {
 
 	return r.Div(&r.DivProps{ClassName: "container"},
-		r.Div(&r.DivProps{DangerouslySetInnerHTML: r.DangerousInnerHTML(`
+		r.Div(&r.DivProps{DangerouslySetInnerHTML: r.NewDangerousInnerHTML(`
 		<h3>Introduction</h3>
 
 		<p>State can be local to components; we can share that state with descendent components

--- a/examples/hellomessage/gen_HelloMessage_reactGen.go
+++ b/examples/hellomessage/gen_HelloMessage_reactGen.go
@@ -4,7 +4,11 @@ package hellomessage
 
 import "myitcv.io/react"
 
-func (h *HelloMessageDef) ShouldComponentUpdateIntf(nextProps, prevState, nextState interface{}) bool {
+type HelloMessageElem struct {
+	react.Element
+}
+
+func (h HelloMessageDef) ShouldComponentUpdateIntf(nextProps, prevState, nextState interface{}) bool {
 	res := false
 
 	{
@@ -13,8 +17,12 @@ func (h *HelloMessageDef) ShouldComponentUpdateIntf(nextProps, prevState, nextSt
 	return res
 }
 
+func buildHelloMessage(cd react.ComponentDef) react.Component {
+	return HelloMessageDef{ComponentDef: cd}
+}
+
 // Props is an auto-generated proxy to the current props of HelloMessage
-func (h *HelloMessageDef) Props() HelloMessageProps {
+func (h HelloMessageDef) Props() HelloMessageProps {
 	uprops := h.ComponentDef.Props()
 	return uprops.(HelloMessageProps)
 }

--- a/examples/hellomessage/hello_message.go
+++ b/examples/hellomessage/hello_message.go
@@ -17,14 +17,18 @@ type HelloMessageProps struct {
 }
 
 // HelloMessage creates instances of the HelloMessage component
-func HelloMessage(p HelloMessageProps) *HelloMessageDef {
-	res := &HelloMessageDef{}
-	r.BlessElement(res, p)
-	return res
+func HelloMessage(p HelloMessageProps) *HelloMessageElem {
+	return &HelloMessageElem{
+		Element: r.CreateElement(buildCmp, p),
+	}
+}
+
+func buildCmp(elem r.ComponentDef) r.Component {
+	return HelloMessageDef{ComponentDef: elem}
 }
 
 // Render renders the HelloMessage component
-func (h *HelloMessageDef) Render() r.Element {
+func (h HelloMessageDef) Render() r.Element {
 	return r.Div(nil,
 		r.S("Hello "+h.Props().Name),
 	)

--- a/examples/imm_examples.go
+++ b/examples/imm_examples.go
@@ -14,10 +14,8 @@ type ImmExamplesDef struct {
 }
 
 // ImmExamples creates instances of the ImmExamples component
-func ImmExamples() *ImmExamplesDef {
-	res := new(ImmExamplesDef)
-	r.BlessElement(res, nil)
-	return res
+func ImmExamples() *ImmExamplesElem {
+	return &ImmExamplesElem{Element: r.CreateElement(buildImmExamples, nil)}
 }
 
 // ImmExamplesState is the state type for the ImmExamples component
@@ -27,7 +25,7 @@ type ImmExamplesState struct {
 }
 
 // ComponentWillMount is a React lifecycle method for the ImmExamples component
-func (p *ImmExamplesDef) ComponentWillMount() {
+func (p ImmExamplesDef) ComponentWillMount() {
 	if !fetchStarted {
 		for i, e := range sources.Range() {
 			go func(i exampleKey, e *source) {
@@ -50,7 +48,7 @@ func (p *ImmExamplesDef) ComponentWillMount() {
 }
 
 // GetInitialState returns in the initial state for the ImmExamples component
-func (p *ImmExamplesDef) GetInitialState() ImmExamplesState {
+func (p ImmExamplesDef) GetInitialState() ImmExamplesState {
 	return ImmExamplesState{
 		examples:     sources,
 		selectedTabs: newTabS(),
@@ -58,7 +56,7 @@ func (p *ImmExamplesDef) GetInitialState() ImmExamplesState {
 }
 
 // Render renders the ImmExamples component
-func (p *ImmExamplesDef) Render() r.Element {
+func (p ImmExamplesDef) Render() r.Element {
 	dc := jsx.HTML(`
 		<h3>Using immutable data structures</h3>
 
@@ -88,7 +86,7 @@ func (p *ImmExamplesDef) Render() r.Element {
 	)
 }
 
-func (p *ImmExamplesDef) renderExample(key exampleKey, title, msg r.Element, jsxSrc string, elem r.Element) r.Element {
+func (p ImmExamplesDef) renderExample(key exampleKey, title, msg r.Element, jsxSrc string, elem r.Element) r.Element {
 
 	var goSrc string
 	src, _ := p.State().examples.Get(key)
@@ -96,12 +94,12 @@ func (p *ImmExamplesDef) renderExample(key exampleKey, title, msg r.Element, jsx
 		goSrc = src.src()
 	}
 
-	var code *r.DangerousInnerHTMLDef
+	var code *r.DangerousInnerHTML
 	switch v, _ := p.State().selectedTabs.Get(key); v {
 	case tabGo:
-		code = r.DangerousInnerHTML(highlightjs.Highlight("go", goSrc, true).Value)
+		code = r.NewDangerousInnerHTML(highlightjs.Highlight("go", goSrc, true).Value)
 	case tabJsx:
-		code = r.DangerousInnerHTML(highlightjs.Highlight("javascript", jsxSrc, true).Value)
+		code = r.NewDangerousInnerHTML(highlightjs.Highlight("javascript", jsxSrc, true).Value)
 	}
 
 	return r.Div(nil,
@@ -135,7 +133,7 @@ func (p *ImmExamplesDef) renderExample(key exampleKey, title, msg r.Element, jsx
 	)
 }
 
-func (p *ImmExamplesDef) buildExampleNavTab(key exampleKey, t tab, title string) *r.LiDef {
+func (p ImmExamplesDef) buildExampleNavTab(key exampleKey, t tab, title string) *r.LiElem {
 	lip := &r.LiProps{Role: "presentation"}
 
 	if v, _ := p.State().selectedTabs.Get(key); v == t {
@@ -153,7 +151,7 @@ func (p *ImmExamplesDef) buildExampleNavTab(key exampleKey, t tab, title string)
 }
 
 type immTabChange struct {
-	e   *ImmExamplesDef
+	e   ImmExamplesDef
 	key exampleKey
 	t   tab
 }

--- a/examples/immtodoapp/gen_TodoApp_reactGen.go
+++ b/examples/immtodoapp/gen_TodoApp_reactGen.go
@@ -4,7 +4,11 @@ package immtodoapp
 
 import "myitcv.io/react"
 
-func (t *TodoAppDef) ShouldComponentUpdateIntf(nextProps, prevState, nextState interface{}) bool {
+type TodoAppElem struct {
+	react.Element
+}
+
+func (t TodoAppDef) ShouldComponentUpdateIntf(nextProps, prevState, nextState interface{}) bool {
 	res := false
 
 	v := prevState.(TodoAppState)
@@ -12,16 +16,20 @@ func (t *TodoAppDef) ShouldComponentUpdateIntf(nextProps, prevState, nextState i
 	return res
 }
 
+func buildTodoApp(cd react.ComponentDef) react.Component {
+	return TodoAppDef{ComponentDef: cd}
+}
+
 // SetState is an auto-generated proxy proxy to update the state for the
 // TodoApp component.  SetState does not immediately mutate t.State()
 // but creates a pending state transition.
-func (t *TodoAppDef) SetState(state TodoAppState) {
+func (t TodoAppDef) SetState(state TodoAppState) {
 	t.ComponentDef.SetState(state)
 }
 
 // State is an auto-generated proxy to return the current state in use for the
 // render of the TodoApp component
-func (t *TodoAppDef) State() TodoAppState {
+func (t TodoAppDef) State() TodoAppState {
 	return t.ComponentDef.State().(TodoAppState)
 }
 
@@ -32,7 +40,7 @@ func (t TodoAppState) IsState() {}
 var _ react.State = TodoAppState{}
 
 // GetInitialStateIntf is an auto-generated proxy to GetInitialState
-func (t *TodoAppDef) GetInitialStateIntf() react.State {
+func (t TodoAppDef) GetInitialStateIntf() react.State {
 	return t.GetInitialState()
 }
 

--- a/examples/immtodoapp/todo_app.go
+++ b/examples/immtodoapp/todo_app.go
@@ -28,21 +28,19 @@ type TodoAppState struct {
 }
 
 // TodoApp creates instances of the TodoApp component
-func TodoApp() *TodoAppDef {
-	res := &TodoAppDef{}
-	r.BlessElement(res, nil)
-	return res
+func TodoApp() *TodoAppElem {
+	return &TodoAppElem{Element: r.CreateElement(buildTodoApp, nil)}
 }
 
-func (t *TodoAppDef) GetInitialState() TodoAppState {
+func (t TodoAppDef) GetInitialState() TodoAppState {
 	return TodoAppState{
 		items: new(itemS),
 	}
 }
 
 // Render renders the TodoApp component
-func (t *TodoAppDef) Render() r.Element {
-	var entries []*r.LiDef
+func (t TodoAppDef) Render() r.Element {
+	var entries []*r.LiElem
 
 	for _, v := range t.State().items.Range() {
 		entry := r.Li(nil, r.S(v.name()))
@@ -74,8 +72,8 @@ func (t *TodoAppDef) Render() r.Element {
 	)
 }
 
-type inputChange struct{ t *TodoAppDef }
-type add struct{ t *TodoAppDef }
+type inputChange struct{ t TodoAppDef }
+type add struct{ t TodoAppDef }
 
 func (i inputChange) OnChange(se *r.SyntheticEvent) {
 	target := se.Target().(*dom.HTMLInputElement)

--- a/examples/markdowneditor/gen_MarkdownEditor_reactGen.go
+++ b/examples/markdowneditor/gen_MarkdownEditor_reactGen.go
@@ -4,7 +4,11 @@ package markdowneditor
 
 import "myitcv.io/react"
 
-func (m *MarkdownEditorDef) ShouldComponentUpdateIntf(nextProps, prevState, nextState interface{}) bool {
+type MarkdownEditorElem struct {
+	react.Element
+}
+
+func (m MarkdownEditorDef) ShouldComponentUpdateIntf(nextProps, prevState, nextState interface{}) bool {
 	res := false
 
 	v := prevState.(MarkdownEditorState)
@@ -12,16 +16,20 @@ func (m *MarkdownEditorDef) ShouldComponentUpdateIntf(nextProps, prevState, next
 	return res
 }
 
+func buildMarkdownEditor(cd react.ComponentDef) react.Component {
+	return MarkdownEditorDef{ComponentDef: cd}
+}
+
 // SetState is an auto-generated proxy proxy to update the state for the
 // MarkdownEditor component.  SetState does not immediately mutate m.State()
 // but creates a pending state transition.
-func (m *MarkdownEditorDef) SetState(state MarkdownEditorState) {
+func (m MarkdownEditorDef) SetState(state MarkdownEditorState) {
 	m.ComponentDef.SetState(state)
 }
 
 // State is an auto-generated proxy to return the current state in use for the
 // render of the MarkdownEditor component
-func (m *MarkdownEditorDef) State() MarkdownEditorState {
+func (m MarkdownEditorDef) State() MarkdownEditorState {
 	return m.ComponentDef.State().(MarkdownEditorState)
 }
 
@@ -32,7 +40,7 @@ func (m MarkdownEditorState) IsState() {}
 var _ react.State = MarkdownEditorState{}
 
 // GetInitialStateIntf is an auto-generated proxy to GetInitialState
-func (m *MarkdownEditorDef) GetInitialStateIntf() react.State {
+func (m MarkdownEditorDef) GetInitialStateIntf() react.State {
 	return m.GetInitialState()
 }
 

--- a/examples/sites/examplesshowcase/app.go
+++ b/examples/sites/examplesshowcase/app.go
@@ -21,15 +21,11 @@ type AppState struct {
 	tab
 }
 
-func App() *AppDef {
-	res := new(AppDef)
-
-	r.BlessElement(res, nil)
-
-	return res
+func App() *AppElem {
+	return &AppElem{Element: r.CreateElement(buildApp, nil)}
 }
 
-func (a *AppDef) Render() r.Element {
+func (a AppDef) Render() r.Element {
 	var view r.Element
 
 	switch a.State().tab {
@@ -67,7 +63,7 @@ func (a *AppDef) Render() r.Element {
 }
 
 type tabChange struct {
-	a *AppDef
+	a AppDef
 	t tab
 }
 
@@ -76,7 +72,7 @@ func (tc tabChange) OnClick(e *r.SyntheticMouseEvent) {
 	e.PreventDefault()
 }
 
-func (a *AppDef) buildLink(n string, t tab, tc tabChange) *r.LiDef {
+func (a AppDef) buildLink(n string, t tab, tc tabChange) *r.LiElem {
 	var lip *r.LiProps
 
 	if a.State().tab == t {

--- a/examples/sites/examplesshowcase/gen_App_reactGen.go
+++ b/examples/sites/examplesshowcase/gen_App_reactGen.go
@@ -4,7 +4,11 @@ package main
 
 import "myitcv.io/react"
 
-func (a *AppDef) ShouldComponentUpdateIntf(nextProps, prevState, nextState interface{}) bool {
+type AppElem struct {
+	react.Element
+}
+
+func (a AppDef) ShouldComponentUpdateIntf(nextProps, prevState, nextState interface{}) bool {
 	res := false
 
 	v := prevState.(AppState)
@@ -12,16 +16,20 @@ func (a *AppDef) ShouldComponentUpdateIntf(nextProps, prevState, nextState inter
 	return res
 }
 
+func buildApp(cd react.ComponentDef) react.Component {
+	return AppDef{ComponentDef: cd}
+}
+
 // SetState is an auto-generated proxy proxy to update the state for the
 // App component.  SetState does not immediately mutate a.State()
 // but creates a pending state transition.
-func (a *AppDef) SetState(state AppState) {
+func (a AppDef) SetState(state AppState) {
 	a.ComponentDef.SetState(state)
 }
 
 // State is an auto-generated proxy to return the current state in use for the
 // render of the App component
-func (a *AppDef) State() AppState {
+func (a AppDef) State() AppState {
 	return a.ComponentDef.State().(AppState)
 }
 
@@ -32,7 +40,7 @@ func (a AppState) IsState() {}
 var _ react.State = AppState{}
 
 // GetInitialStateIntf is an auto-generated proxy to GetInitialState
-func (a *AppDef) GetInitialStateIntf() react.State {
+func (a AppDef) GetInitialStateIntf() react.State {
 	return AppState{}
 }
 

--- a/examples/sites/globalstate/app.go
+++ b/examples/sites/globalstate/app.go
@@ -13,15 +13,13 @@ type AppState struct {
 	hideViewer bool
 }
 
-func App() *AppDef {
-	res := new(AppDef)
-	r.BlessElement(res, nil)
-	return res
+func App() *AppElem {
+	return &AppElem{Element: r.CreateElement(buildApp, nil)}
 }
 
-func (a *AppDef) Render() r.Element {
-	var viewer *r.DivDef
-	var showHide *r.ButtonDef
+func (a AppDef) Render() r.Element {
+	var viewer *r.DivElem
+	var showHide *r.ButtonElem
 
 	if a.State().hideViewer {
 		showHide = r.Button(
@@ -51,7 +49,7 @@ func (a *AppDef) Render() r.Element {
 }
 
 type hideClick struct {
-	*AppDef
+	AppDef
 	showHide bool
 }
 

--- a/examples/sites/globalstate/gen_App_reactGen.go
+++ b/examples/sites/globalstate/gen_App_reactGen.go
@@ -4,7 +4,11 @@ package main
 
 import "myitcv.io/react"
 
-func (a *AppDef) ShouldComponentUpdateIntf(nextProps, prevState, nextState interface{}) bool {
+type AppElem struct {
+	react.Element
+}
+
+func (a AppDef) ShouldComponentUpdateIntf(nextProps, prevState, nextState interface{}) bool {
 	res := false
 
 	v := prevState.(AppState)
@@ -12,16 +16,20 @@ func (a *AppDef) ShouldComponentUpdateIntf(nextProps, prevState, nextState inter
 	return res
 }
 
+func buildApp(cd react.ComponentDef) react.Component {
+	return AppDef{ComponentDef: cd}
+}
+
 // SetState is an auto-generated proxy proxy to update the state for the
 // App component.  SetState does not immediately mutate a.State()
 // but creates a pending state transition.
-func (a *AppDef) SetState(state AppState) {
+func (a AppDef) SetState(state AppState) {
 	a.ComponentDef.SetState(state)
 }
 
 // State is an auto-generated proxy to return the current state in use for the
 // render of the App component
-func (a *AppDef) State() AppState {
+func (a AppDef) State() AppState {
 	return a.ComponentDef.State().(AppState)
 }
 
@@ -32,7 +40,7 @@ func (a AppState) IsState() {}
 var _ react.State = AppState{}
 
 // GetInitialStateIntf is an auto-generated proxy to GetInitialState
-func (a *AppDef) GetInitialStateIntf() react.State {
+func (a AppDef) GetInitialStateIntf() react.State {
 	return AppState{}
 }
 

--- a/examples/sites/globalstate/gen_PersonChooser_reactGen.go
+++ b/examples/sites/globalstate/gen_PersonChooser_reactGen.go
@@ -4,7 +4,11 @@ package main
 
 import "myitcv.io/react"
 
-func (p *PersonChooserDef) ShouldComponentUpdateIntf(nextProps, prevState, nextState interface{}) bool {
+type PersonChooserElem struct {
+	react.Element
+}
+
+func (p PersonChooserDef) ShouldComponentUpdateIntf(nextProps, prevState, nextState interface{}) bool {
 	res := false
 
 	{
@@ -15,16 +19,20 @@ func (p *PersonChooserDef) ShouldComponentUpdateIntf(nextProps, prevState, nextS
 	return res
 }
 
+func buildPersonChooser(cd react.ComponentDef) react.Component {
+	return PersonChooserDef{ComponentDef: cd}
+}
+
 // SetState is an auto-generated proxy proxy to update the state for the
 // PersonChooser component.  SetState does not immediately mutate p.State()
 // but creates a pending state transition.
-func (p *PersonChooserDef) SetState(state PersonChooserState) {
+func (p PersonChooserDef) SetState(state PersonChooserState) {
 	p.ComponentDef.SetState(state)
 }
 
 // State is an auto-generated proxy to return the current state in use for the
 // render of the PersonChooser component
-func (p *PersonChooserDef) State() PersonChooserState {
+func (p PersonChooserDef) State() PersonChooserState {
 	return p.ComponentDef.State().(PersonChooserState)
 }
 
@@ -35,7 +43,7 @@ func (p PersonChooserState) IsState() {}
 var _ react.State = PersonChooserState{}
 
 // GetInitialStateIntf is an auto-generated proxy to GetInitialState
-func (p *PersonChooserDef) GetInitialStateIntf() react.State {
+func (p PersonChooserDef) GetInitialStateIntf() react.State {
 	return PersonChooserState{}
 }
 
@@ -44,7 +52,7 @@ func (p PersonChooserState) EqualsIntf(val interface{}) bool {
 }
 
 // Props is an auto-generated proxy to the current props of PersonChooser
-func (p *PersonChooserDef) Props() PersonChooserProps {
+func (p PersonChooserDef) Props() PersonChooserProps {
 	uprops := p.ComponentDef.Props()
 	return uprops.(PersonChooserProps)
 }

--- a/examples/sites/globalstate/gen_PersonViewer_reactGen.go
+++ b/examples/sites/globalstate/gen_PersonViewer_reactGen.go
@@ -4,7 +4,11 @@ package main
 
 import "myitcv.io/react"
 
-func (p *PersonViewerDef) ShouldComponentUpdateIntf(nextProps, prevState, nextState interface{}) bool {
+type PersonViewerElem struct {
+	react.Element
+}
+
+func (p PersonViewerDef) ShouldComponentUpdateIntf(nextProps, prevState, nextState interface{}) bool {
 	res := false
 
 	v := prevState.(PersonViewerState)
@@ -12,16 +16,20 @@ func (p *PersonViewerDef) ShouldComponentUpdateIntf(nextProps, prevState, nextSt
 	return res
 }
 
+func buildPersonViewer(cd react.ComponentDef) react.Component {
+	return PersonViewerDef{ComponentDef: cd}
+}
+
 // SetState is an auto-generated proxy proxy to update the state for the
 // PersonViewer component.  SetState does not immediately mutate p.State()
 // but creates a pending state transition.
-func (p *PersonViewerDef) SetState(state PersonViewerState) {
+func (p PersonViewerDef) SetState(state PersonViewerState) {
 	p.ComponentDef.SetState(state)
 }
 
 // State is an auto-generated proxy to return the current state in use for the
 // render of the PersonViewer component
-func (p *PersonViewerDef) State() PersonViewerState {
+func (p PersonViewerDef) State() PersonViewerState {
 	return p.ComponentDef.State().(PersonViewerState)
 }
 
@@ -32,7 +40,7 @@ func (p PersonViewerState) IsState() {}
 var _ react.State = PersonViewerState{}
 
 // GetInitialStateIntf is an auto-generated proxy to GetInitialState
-func (p *PersonViewerDef) GetInitialStateIntf() react.State {
+func (p PersonViewerDef) GetInitialStateIntf() react.State {
 	return PersonViewerState{}
 }
 

--- a/examples/sites/globalstate/person_chooser.go
+++ b/examples/sites/globalstate/person_chooser.go
@@ -29,13 +29,11 @@ type PersonChooserState struct {
 	currPersonSub *state.Sub
 }
 
-func PersonChooser(props PersonChooserProps) *PersonChooserDef {
-	res := new(PersonChooserDef)
-	r.BlessElement(res, props)
-	return res
+func PersonChooser(props PersonChooserProps) *PersonChooserElem {
+	return &PersonChooserElem{Element: r.CreateElement(buildPersonChooser, props)}
 }
 
-func (p *PersonChooserDef) ComponentWillMount() {
+func (p PersonChooserDef) ComponentWillMount() {
 	sub := p.Props().PersonState.Subscribe(p.personStateChanged)
 	st := p.State()
 	st.currPersonSub = sub
@@ -43,11 +41,11 @@ func (p *PersonChooserDef) ComponentWillMount() {
 	p.SetState(st)
 }
 
-func (p *PersonChooserDef) ComponentWillUnmount() {
+func (p PersonChooserDef) ComponentWillUnmount() {
 	p.State().currPersonSub.Clear()
 }
 
-func (p *PersonChooserDef) Render() r.Element {
+func (p PersonChooserDef) Render() r.Element {
 
 	ppl := sortPeopleKeysByName(state.State.Root().People().Get())
 
@@ -66,7 +64,7 @@ func (p *PersonChooserDef) Render() r.Element {
 	)
 }
 
-func (p *PersonChooserDef) personStateChanged() {
+func (p PersonChooserDef) personStateChanged() {
 	s := p.State()
 	s.currPerson = p.Props().PersonState.Get()
 	p.SetState(s)
@@ -89,7 +87,7 @@ func (p personLabel) Label() string {
 	return p.Person.Name()
 }
 
-type personSelected struct{ *PersonChooserDef }
+type personSelected struct{ PersonChooserDef }
 
 func (p personSelected) OnSelect(l c.Label) {
 	pl := l.(personLabel)

--- a/examples/sites/globalstate/person_viewer.go
+++ b/examples/sites/globalstate/person_viewer.go
@@ -18,13 +18,11 @@ type PersonViewerState struct {
 	curPersSub *state.Sub
 }
 
-func PersonViewer() *PersonViewerDef {
-	res := new(PersonViewerDef)
-	r.BlessElement(res, nil)
-	return res
+func PersonViewer() *PersonViewerElem {
+	return &PersonViewerElem{Element: r.CreateElement(buildPersonViewer, nil)}
 }
 
-func (p *PersonViewerDef) ComponentWillMount() {
+func (p PersonViewerDef) ComponentWillMount() {
 	curPersSub := state.State.CurrentPerson().Subscribe(p.currPersonUpdated)
 
 	p.SetState(PersonViewerState{
@@ -33,11 +31,11 @@ func (p *PersonViewerDef) ComponentWillMount() {
 	})
 }
 
-func (p *PersonViewerDef) ComponentWillUnmount() {
+func (p PersonViewerDef) ComponentWillUnmount() {
 	p.State().curPersSub.Clear()
 }
 
-func (p *PersonViewerDef) Render() r.Element {
+func (p PersonViewerDef) Render() r.Element {
 	st := p.State()
 
 	if st.p != nil {
@@ -47,7 +45,7 @@ func (p *PersonViewerDef) Render() r.Element {
 	return r.P(nil, r.S("(no person selected)"))
 }
 
-func (p *PersonViewerDef) currPersonUpdated() {
+func (p PersonViewerDef) currPersonUpdated() {
 	st := p.State()
 	st.p = state.State.CurrentPerson().Get()
 	p.SetState(st)

--- a/examples/sites/helloworld/app.go
+++ b/examples/sites/helloworld/app.go
@@ -10,13 +10,11 @@ type AppDef struct {
 	r.ComponentDef
 }
 
-func App() *AppDef {
-	res := new(AppDef)
-	r.BlessElement(res, nil)
-	return res
+func App() *AppElem {
+	return &AppElem{Element: r.CreateElement(buildApp, nil)}
 }
 
-func (a *AppDef) Render() r.Element {
+func (a AppDef) Render() r.Element {
 	return r.Div(nil,
 		r.H1(nil,
 			r.S("Hello World"),

--- a/examples/sites/helloworld/gen_App_reactGen.go
+++ b/examples/sites/helloworld/gen_App_reactGen.go
@@ -2,8 +2,18 @@
 
 package main
 
-func (a *AppDef) ShouldComponentUpdateIntf(nextProps, prevState, nextState interface{}) bool {
+import "myitcv.io/react"
+
+type AppElem struct {
+	react.Element
+}
+
+func (a AppDef) ShouldComponentUpdateIntf(nextProps, prevState, nextState interface{}) bool {
 	res := false
 
 	return res
+}
+
+func buildApp(cd react.ComponentDef) react.Component {
+	return AppDef{ComponentDef: cd}
 }

--- a/examples/sites/latency/app.go
+++ b/examples/sites/latency/app.go
@@ -15,12 +15,10 @@ type AppDef struct {
 	r.ComponentDef
 }
 
-func App() *AppDef {
-	res := new(AppDef)
-	r.BlessElement(res, nil)
-	return res
+func App() *AppElem {
+	return &AppElem{Element: r.CreateElement(buildApp, nil)}
 }
 
-func (a *AppDef) Render() r.Element {
+func (a AppDef) Render() r.Element {
 	return Latency()
 }

--- a/examples/sites/latency/gen_App_reactGen.go
+++ b/examples/sites/latency/gen_App_reactGen.go
@@ -2,8 +2,18 @@
 
 package main
 
-func (a *AppDef) ShouldComponentUpdateIntf(nextProps, prevState, nextState interface{}) bool {
+import "myitcv.io/react"
+
+type AppElem struct {
+	react.Element
+}
+
+func (a AppDef) ShouldComponentUpdateIntf(nextProps, prevState, nextState interface{}) bool {
 	res := false
 
 	return res
+}
+
+func buildApp(cd react.ComponentDef) react.Component {
+	return AppDef{ComponentDef: cd}
 }

--- a/examples/sites/latency/gen_Latency_reactGen.go
+++ b/examples/sites/latency/gen_Latency_reactGen.go
@@ -4,7 +4,11 @@ package main
 
 import "myitcv.io/react"
 
-func (l *LatencyDef) ShouldComponentUpdateIntf(nextProps, prevState, nextState interface{}) bool {
+type LatencyElem struct {
+	react.Element
+}
+
+func (l LatencyDef) ShouldComponentUpdateIntf(nextProps, prevState, nextState interface{}) bool {
 	res := false
 
 	v := prevState.(LatencyState)
@@ -12,16 +16,20 @@ func (l *LatencyDef) ShouldComponentUpdateIntf(nextProps, prevState, nextState i
 	return res
 }
 
+func buildLatency(cd react.ComponentDef) react.Component {
+	return LatencyDef{ComponentDef: cd}
+}
+
 // SetState is an auto-generated proxy proxy to update the state for the
 // Latency component.  SetState does not immediately mutate l.State()
 // but creates a pending state transition.
-func (l *LatencyDef) SetState(state LatencyState) {
+func (l LatencyDef) SetState(state LatencyState) {
 	l.ComponentDef.SetState(state)
 }
 
 // State is an auto-generated proxy to return the current state in use for the
 // render of the Latency component
-func (l *LatencyDef) State() LatencyState {
+func (l LatencyDef) State() LatencyState {
 	return l.ComponentDef.State().(LatencyState)
 }
 
@@ -32,7 +40,7 @@ func (l LatencyState) IsState() {}
 var _ react.State = LatencyState{}
 
 // GetInitialStateIntf is an auto-generated proxy to GetInitialState
-func (l *LatencyDef) GetInitialStateIntf() react.State {
+func (l LatencyDef) GetInitialStateIntf() react.State {
 	return LatencyState{}
 }
 

--- a/examples/sites/latency/latency.go
+++ b/examples/sites/latency/latency.go
@@ -58,13 +58,11 @@ type LatencyState struct {
 	*latencies
 }
 
-func Latency() *LatencyDef {
-	res := &LatencyDef{}
-	r.BlessElement(res, nil)
-	return res
+func Latency() *LatencyElem {
+	return &LatencyElem{Element: r.CreateElement(buildLatency, nil)}
 }
 
-func (l *LatencyDef) Render() r.Element {
+func (l LatencyDef) Render() r.Element {
 	var c r.Element
 
 	if l.State().output {
@@ -95,7 +93,7 @@ func (l *LatencyDef) Render() r.Element {
 	)
 }
 
-func (l *LatencyDef) renderInput() r.Element {
+func (l LatencyDef) renderInput() r.Element {
 	return r.Form(&r.FormProps{ClassName: "LatencyForm"},
 		r.Div(&r.DivProps{ClassName: "group"},
 			r.Input(&r.InputProps{
@@ -161,7 +159,7 @@ func (l *LatencyDef) renderOutput() r.Element {
 				regClass += " with-timings speed-fast"
 			}
 
-			genTiming := func(f time.Duration, n, l string) *r.SpanDef {
+			genTiming := func(f time.Duration, n, l string) *r.SpanElem {
 				w := fmt.Sprintf("%.3fpx", float64(f)/float64(maxTot)*resultWidth)
 				rs := fmt.Sprintf("%v (%v)", l, f)
 
@@ -208,9 +206,9 @@ func (l *LatencyDef) reset(e *r.SyntheticMouseEvent) {
 	e.PreventDefault()
 }
 
-type urlChange struct{ l *LatencyDef }
-type altUrlChange struct{ l *LatencyDef }
-type check struct{ l *LatencyDef }
+type urlChange struct{ l LatencyDef }
+type altUrlChange struct{ l LatencyDef }
+type check struct{ l LatencyDef }
 
 func (u urlChange) OnChange(se *r.SyntheticEvent) {
 	target := se.Target().(*dom.HTMLInputElement)

--- a/examples/timer/gen_Timer_reactGen.go
+++ b/examples/timer/gen_Timer_reactGen.go
@@ -4,7 +4,11 @@ package timer
 
 import "myitcv.io/react"
 
-func (t *TimerDef) ShouldComponentUpdateIntf(nextProps, prevState, nextState interface{}) bool {
+type TimerElem struct {
+	react.Element
+}
+
+func (t TimerDef) ShouldComponentUpdateIntf(nextProps, prevState, nextState interface{}) bool {
 	res := false
 
 	v := prevState.(TimerState)
@@ -12,16 +16,20 @@ func (t *TimerDef) ShouldComponentUpdateIntf(nextProps, prevState, nextState int
 	return res
 }
 
+func buildTimer(cd react.ComponentDef) react.Component {
+	return TimerDef{ComponentDef: cd}
+}
+
 // SetState is an auto-generated proxy proxy to update the state for the
 // Timer component.  SetState does not immediately mutate t.State()
 // but creates a pending state transition.
-func (t *TimerDef) SetState(state TimerState) {
+func (t TimerDef) SetState(state TimerState) {
 	t.ComponentDef.SetState(state)
 }
 
 // State is an auto-generated proxy to return the current state in use for the
 // render of the Timer component
-func (t *TimerDef) State() TimerState {
+func (t TimerDef) State() TimerState {
 	return t.ComponentDef.State().(TimerState)
 }
 
@@ -32,7 +40,7 @@ func (t TimerState) IsState() {}
 var _ react.State = TimerState{}
 
 // GetInitialStateIntf is an auto-generated proxy to GetInitialState
-func (t *TimerDef) GetInitialStateIntf() react.State {
+func (t TimerDef) GetInitialStateIntf() react.State {
 	return TimerState{}
 }
 

--- a/examples/timer/timer.go
+++ b/examples/timer/timer.go
@@ -22,14 +22,12 @@ type TimerState struct {
 }
 
 // Timer creates instances of the Timer component
-func Timer() *TimerDef {
-	res := new(TimerDef)
-	r.BlessElement(res, nil)
-	return res
+func Timer() *TimerElem {
+	return &TimerElem{Element: r.CreateElement(buildTimer, nil)}
 }
 
 // ComponentWillMount is a React lifecycle method for the Timer component
-func (t *TimerDef) ComponentWillMount() {
+func (t TimerDef) ComponentWillMount() {
 	tick := time.NewTicker(time.Second * 1)
 
 	s := t.State()
@@ -48,12 +46,12 @@ func (t *TimerDef) ComponentWillMount() {
 	}()
 }
 
-func (t *TimerDef) ComponentWillUnmount() {
+func (t TimerDef) ComponentWillUnmount() {
 	t.State().ticker.Stop()
 }
 
 // Render renders the Timer component
-func (t *TimerDef) Render() r.Element {
+func (t TimerDef) Render() r.Element {
 	return r.Div(nil,
 		r.Div(nil,
 			r.S(fmt.Sprintf("Seconds elapsed %.0f", t.State().secondsElapsed)),

--- a/examples/todoapp/gen_TodoApp_reactGen.go
+++ b/examples/todoapp/gen_TodoApp_reactGen.go
@@ -4,7 +4,11 @@ package todoapp
 
 import "myitcv.io/react"
 
-func (t *TodoAppDef) ShouldComponentUpdateIntf(nextProps, prevState, nextState interface{}) bool {
+type TodoAppElem struct {
+	react.Element
+}
+
+func (t TodoAppDef) ShouldComponentUpdateIntf(nextProps, prevState, nextState interface{}) bool {
 	res := false
 
 	v := prevState.(TodoAppState)
@@ -12,16 +16,20 @@ func (t *TodoAppDef) ShouldComponentUpdateIntf(nextProps, prevState, nextState i
 	return res
 }
 
+func buildTodoApp(cd react.ComponentDef) react.Component {
+	return TodoAppDef{ComponentDef: cd}
+}
+
 // SetState is an auto-generated proxy proxy to update the state for the
 // TodoApp component.  SetState does not immediately mutate t.State()
 // but creates a pending state transition.
-func (t *TodoAppDef) SetState(state TodoAppState) {
+func (t TodoAppDef) SetState(state TodoAppState) {
 	t.ComponentDef.SetState(state)
 }
 
 // State is an auto-generated proxy to return the current state in use for the
 // render of the TodoApp component
-func (t *TodoAppDef) State() TodoAppState {
+func (t TodoAppDef) State() TodoAppState {
 	return t.ComponentDef.State().(TodoAppState)
 }
 
@@ -32,7 +40,7 @@ func (t TodoAppState) IsState() {}
 var _ react.State = TodoAppState{}
 
 // GetInitialStateIntf is an auto-generated proxy to GetInitialState
-func (t *TodoAppDef) GetInitialStateIntf() react.State {
+func (t TodoAppDef) GetInitialStateIntf() react.State {
 	return TodoAppState{}
 }
 

--- a/examples/todoapp/todo_app.go
+++ b/examples/todoapp/todo_app.go
@@ -21,10 +21,8 @@ type TodoAppState struct {
 }
 
 // TodoApp creates instances of the TodoApp component
-func TodoApp() *TodoAppDef {
-	res := &TodoAppDef{}
-	r.BlessElement(res, nil)
-	return res
+func TodoApp() *TodoAppElem {
+	return &TodoAppElem{Element: r.CreateElement(buildTodoApp, nil)}
 }
 
 // Equals must be defined because struct val instances of TodoAppState cannot
@@ -50,8 +48,8 @@ func (c TodoAppState) Equals(v TodoAppState) bool {
 }
 
 // Render renders the TodoApp component
-func (t *TodoAppDef) Render() r.Element {
-	var entries []*r.LiDef
+func (t TodoAppDef) Render() r.Element {
+	var entries []*r.LiElem
 
 	for _, v := range t.State().items {
 		entry := r.Li(nil, r.S(v))
@@ -83,8 +81,8 @@ func (t *TodoAppDef) Render() r.Element {
 	)
 }
 
-type inputChange struct{ t *TodoAppDef }
-type add struct{ t *TodoAppDef }
+type inputChange struct{ t TodoAppDef }
+type add struct{ t TodoAppDef }
 
 func (i inputChange) OnChange(se *r.SyntheticEvent) {
 	target := se.Target().(*dom.HTMLInputElement)

--- a/footer.go
+++ b/footer.go
@@ -3,11 +3,9 @@
 
 package react
 
-import "github.com/gopherjs/gopherjs/js"
-
-// FooterDef is the React component definition corresponding to the HTML <footer> element
-type FooterDef struct {
-	underlying *js.Object
+// FooterElem is the React element definition corresponding to the HTML <footer> element
+type FooterElem struct {
+	Element
 }
 
 // _FooterProps are the props for a <footer> component
@@ -15,10 +13,8 @@ type _FooterProps struct {
 	*BasicHTMLElement
 }
 
-func (d *FooterDef) reactElement() {}
-
 // Footer creates a new instance of a <footer> element with the provided props and children
-func Footer(props *FooterProps, children ...Element) *FooterDef {
+func Footer(props *FooterProps, children ...Element) *FooterElem {
 
 	rProps := &_FooterProps{
 		BasicHTMLElement: newBasicHTMLElement(),
@@ -36,5 +32,5 @@ func Footer(props *FooterProps, children ...Element) *FooterDef {
 
 	underlying := react.Call("createElement", args...)
 
-	return &FooterDef{underlying: underlying}
+	return &FooterElem{Element: elementHolder{elem: underlying}}
 }

--- a/form.go
+++ b/form.go
@@ -10,16 +10,18 @@ type FormDef struct {
 	underlying *js.Object
 }
 
+type FormElem struct {
+	Element
+}
+
 // _FormProps defines the properties for the <form> element
 type _FormProps struct {
 	*BasicHTMLElement
 }
 
-func (d *FormDef) reactElement() {}
-
 // Form creates a new instance of a <form> element with the provided props and
 // children
-func Form(props *FormProps, children ...Element) *FormDef {
+func Form(props *FormProps, children ...Element) *FormElem {
 
 	rProps := &_FormProps{
 		BasicHTMLElement: newBasicHTMLElement(),
@@ -37,5 +39,5 @@ func Form(props *FormProps, children ...Element) *FormDef {
 
 	underlying := react.Call("createElement", args...)
 
-	return &FormDef{underlying: underlying}
+	return &FormElem{Element: elementHolder{elem: underlying}}
 }

--- a/gen_AProps_reactGen.go
+++ b/gen_AProps_reactGen.go
@@ -5,7 +5,7 @@ package react
 // APropsDef defines the properties for the <a> element
 type AProps struct {
 	ClassName               string
-	DangerouslySetInnerHTML *DangerousInnerHTMLDef
+	DangerouslySetInnerHTML *DangerousInnerHTML
 	Href                    string
 	ID                      string
 	Key                     string

--- a/gen_BRProps_reactGen.go
+++ b/gen_BRProps_reactGen.go
@@ -5,7 +5,7 @@ package react
 // BRProps defines the properties for the <br> element
 type BRProps struct {
 	ClassName               string
-	DangerouslySetInnerHTML *DangerousInnerHTMLDef
+	DangerouslySetInnerHTML *DangerousInnerHTML
 	ID                      string
 	Key                     string
 

--- a/gen_ButtonProps_reactGen.go
+++ b/gen_ButtonProps_reactGen.go
@@ -5,7 +5,7 @@ package react
 // ButtonProps defines the properties for the <button> element
 type ButtonProps struct {
 	ClassName               string
-	DangerouslySetInnerHTML *DangerousInnerHTMLDef
+	DangerouslySetInnerHTML *DangerousInnerHTML
 	ID                      string
 	Key                     string
 

--- a/gen_CodeProps_reactGen.go
+++ b/gen_CodeProps_reactGen.go
@@ -5,7 +5,7 @@ package react
 // CodeProps defines the properties for the <code> element
 type CodeProps struct {
 	ClassName               string
-	DangerouslySetInnerHTML *DangerousInnerHTMLDef
+	DangerouslySetInnerHTML *DangerousInnerHTML
 	ID                      string
 	Key                     string
 

--- a/gen_DivProps_reactGen.go
+++ b/gen_DivProps_reactGen.go
@@ -5,7 +5,7 @@ package react
 // DivProps are the props for a <div> component
 type DivProps struct {
 	ClassName               string
-	DangerouslySetInnerHTML *DangerousInnerHTMLDef
+	DangerouslySetInnerHTML *DangerousInnerHTML
 	ID                      string
 	Key                     string
 

--- a/gen_FooterProps_reactGen.go
+++ b/gen_FooterProps_reactGen.go
@@ -5,7 +5,7 @@ package react
 // FooterProps are the props for a <footer> component
 type FooterProps struct {
 	ClassName               string
-	DangerouslySetInnerHTML *DangerousInnerHTMLDef
+	DangerouslySetInnerHTML *DangerousInnerHTML
 	ID                      string
 	Key                     string
 

--- a/gen_FormProps_reactGen.go
+++ b/gen_FormProps_reactGen.go
@@ -5,7 +5,7 @@ package react
 // FormProps defines the properties for the <form> element
 type FormProps struct {
 	ClassName               string
-	DangerouslySetInnerHTML *DangerousInnerHTMLDef
+	DangerouslySetInnerHTML *DangerousInnerHTML
 	ID                      string
 	Key                     string
 

--- a/gen_H1Props_reactGen.go
+++ b/gen_H1Props_reactGen.go
@@ -5,7 +5,7 @@ package react
 // H1Props defines the properties for the <h1> element
 type H1Props struct {
 	ClassName               string
-	DangerouslySetInnerHTML *DangerousInnerHTMLDef
+	DangerouslySetInnerHTML *DangerousInnerHTML
 	ID                      string
 	Key                     string
 

--- a/gen_H3Props_reactGen.go
+++ b/gen_H3Props_reactGen.go
@@ -5,7 +5,7 @@ package react
 // H3Props defines the properties for the <h3> element
 type H3Props struct {
 	ClassName               string
-	DangerouslySetInnerHTML *DangerousInnerHTMLDef
+	DangerouslySetInnerHTML *DangerousInnerHTML
 	ID                      string
 	Key                     string
 

--- a/gen_H4Props_reactGen.go
+++ b/gen_H4Props_reactGen.go
@@ -5,7 +5,7 @@ package react
 // H4Props defines the properties for the <h4> element
 type H4Props struct {
 	ClassName               string
-	DangerouslySetInnerHTML *DangerousInnerHTMLDef
+	DangerouslySetInnerHTML *DangerousInnerHTML
 	ID                      string
 	Key                     string
 

--- a/gen_HRProps_reactGen.go
+++ b/gen_HRProps_reactGen.go
@@ -5,7 +5,7 @@ package react
 // HRProps defines the properties for the <hr> element
 type HRProps struct {
 	ClassName               string
-	DangerouslySetInnerHTML *DangerousInnerHTMLDef
+	DangerouslySetInnerHTML *DangerousInnerHTML
 	ID                      string
 	Key                     string
 

--- a/gen_IProps_reactGen.go
+++ b/gen_IProps_reactGen.go
@@ -5,7 +5,7 @@ package react
 // IProps are the props for a <i> component
 type IProps struct {
 	ClassName               string
-	DangerouslySetInnerHTML *DangerousInnerHTMLDef
+	DangerouslySetInnerHTML *DangerousInnerHTML
 	ID                      string
 	Key                     string
 

--- a/gen_ImgProps_reactGen.go
+++ b/gen_ImgProps_reactGen.go
@@ -5,7 +5,7 @@ package react
 // ImgProps are the props for a <Img> component
 type ImgProps struct {
 	ClassName               string
-	DangerouslySetInnerHTML *DangerousInnerHTMLDef
+	DangerouslySetInnerHTML *DangerousInnerHTML
 	ID                      string
 	Key                     string
 

--- a/gen_InputProps_reactGen.go
+++ b/gen_InputProps_reactGen.go
@@ -5,7 +5,7 @@ package react
 // InputProps defines the properties for the <input> element
 type InputProps struct {
 	ClassName               string
-	DangerouslySetInnerHTML *DangerousInnerHTMLDef
+	DangerouslySetInnerHTML *DangerousInnerHTML
 	DefaultValue            string
 	ID                      string
 	Key                     string

--- a/gen_LabelProps_reactGen.go
+++ b/gen_LabelProps_reactGen.go
@@ -5,7 +5,7 @@ package react
 // LabelProps defines the properties for the <label> element
 type LabelProps struct {
 	ClassName               string
-	DangerouslySetInnerHTML *DangerousInnerHTMLDef
+	DangerouslySetInnerHTML *DangerousInnerHTML
 	For                     string
 	ID                      string
 	Key                     string

--- a/gen_LiProps_reactGen.go
+++ b/gen_LiProps_reactGen.go
@@ -5,7 +5,7 @@ package react
 // LiProps defines the properties for the <li> element
 type LiProps struct {
 	ClassName               string
-	DangerouslySetInnerHTML *DangerousInnerHTMLDef
+	DangerouslySetInnerHTML *DangerousInnerHTML
 	ID                      string
 	Key                     string
 

--- a/gen_NavProps_reactGen.go
+++ b/gen_NavProps_reactGen.go
@@ -5,7 +5,7 @@ package react
 // NavProps defines the properties for the <nav> element
 type NavProps struct {
 	ClassName               string
-	DangerouslySetInnerHTML *DangerousInnerHTMLDef
+	DangerouslySetInnerHTML *DangerousInnerHTML
 	ID                      string
 	Key                     string
 

--- a/gen_OptionProps_reactGen.go
+++ b/gen_OptionProps_reactGen.go
@@ -5,7 +5,7 @@ package react
 // OptionProps defines the properties for the <option> element
 type OptionProps struct {
 	ClassName               string
-	DangerouslySetInnerHTML *DangerousInnerHTMLDef
+	DangerouslySetInnerHTML *DangerousInnerHTML
 	ID                      string
 	Key                     string
 

--- a/gen_PProps_reactGen.go
+++ b/gen_PProps_reactGen.go
@@ -5,7 +5,7 @@ package react
 // PProps are the props for a <div> component
 type PProps struct {
 	ClassName               string
-	DangerouslySetInnerHTML *DangerousInnerHTMLDef
+	DangerouslySetInnerHTML *DangerousInnerHTML
 	ID                      string
 	Key                     string
 

--- a/gen_PreProps_reactGen.go
+++ b/gen_PreProps_reactGen.go
@@ -5,7 +5,7 @@ package react
 // PreProps defines the properties for the <pre> element
 type PreProps struct {
 	ClassName               string
-	DangerouslySetInnerHTML *DangerousInnerHTMLDef
+	DangerouslySetInnerHTML *DangerousInnerHTML
 	ID                      string
 	Key                     string
 

--- a/gen_SelectProps_reactGen.go
+++ b/gen_SelectProps_reactGen.go
@@ -5,7 +5,7 @@ package react
 // SelectProps are the props for a <select> component
 type SelectProps struct {
 	ClassName               string
-	DangerouslySetInnerHTML *DangerousInnerHTMLDef
+	DangerouslySetInnerHTML *DangerousInnerHTML
 	ID                      string
 	Key                     string
 

--- a/gen_SpanProps_reactGen.go
+++ b/gen_SpanProps_reactGen.go
@@ -5,7 +5,7 @@ package react
 // SpanProps defines the properties for the <p> element
 type SpanProps struct {
 	ClassName               string
-	DangerouslySetInnerHTML *DangerousInnerHTMLDef
+	DangerouslySetInnerHTML *DangerousInnerHTML
 	ID                      string
 	Key                     string
 

--- a/gen_TextAreaProps_reactGen.go
+++ b/gen_TextAreaProps_reactGen.go
@@ -6,7 +6,7 @@ package react
 type TextAreaProps struct {
 	ClassName               string
 	Cols                    uint
-	DangerouslySetInnerHTML *DangerousInnerHTMLDef
+	DangerouslySetInnerHTML *DangerousInnerHTML
 	DefaultValue            string
 	ID                      string
 	Key                     string

--- a/gen_UlProps_reactGen.go
+++ b/gen_UlProps_reactGen.go
@@ -5,7 +5,7 @@ package react
 // UlProps defines the properties for the <ul> element
 type UlProps struct {
 	ClassName               string
-	DangerouslySetInnerHTML *DangerousInnerHTMLDef
+	DangerouslySetInnerHTML *DangerousInnerHTML
 	ID                      string
 	Key                     string
 

--- a/h1.go
+++ b/h1.go
@@ -3,11 +3,9 @@
 
 package react
 
-import "github.com/gopherjs/gopherjs/js"
-
-// H1Def is the React component definition corresponding to the HTML <h1> element
-type H1Def struct {
-	underlying *js.Object
+// H1Elem is the React element definition corresponding to the HTML <h1> element
+type H1Elem struct {
+	Element
 }
 
 // _H1Props defines the properties for the <h1> element
@@ -15,11 +13,9 @@ type _H1Props struct {
 	*BasicHTMLElement
 }
 
-func (d *H1Def) reactElement() {}
-
 // H1 creates a new instance of a <h1> element with the provided props and
 // child
-func H1(props *H1Props, children ...Element) *H1Def {
+func H1(props *H1Props, children ...Element) *H1Elem {
 
 	rProps := &_H1Props{
 		BasicHTMLElement: newBasicHTMLElement(),
@@ -37,5 +33,5 @@ func H1(props *H1Props, children ...Element) *H1Def {
 
 	underlying := react.Call("createElement", args...)
 
-	return &H1Def{underlying: underlying}
+	return &H1Elem{Element: elementHolder{elem: underlying}}
 }

--- a/h3.go
+++ b/h3.go
@@ -3,11 +3,9 @@
 
 package react
 
-import "github.com/gopherjs/gopherjs/js"
-
-// H3Def is the React component definition corresponding to the HTML <h3> element
-type H3Def struct {
-	underlying *js.Object
+// H3Elem is the React element definition corresponding to the HTML <h3> element
+type H3Elem struct {
+	Element
 }
 
 // _H3Props defines the properties for the <h3> element
@@ -15,11 +13,9 @@ type _H3Props struct {
 	*BasicHTMLElement
 }
 
-func (d *H3Def) reactElement() {}
-
 // H3 creates a new instance of a <h3> element with the provided props and
 // child
-func H3(props *H3Props, children ...Element) *H3Def {
+func H3(props *H3Props, children ...Element) *H3Elem {
 
 	rProps := &_H3Props{
 		BasicHTMLElement: newBasicHTMLElement(),
@@ -37,5 +33,5 @@ func H3(props *H3Props, children ...Element) *H3Def {
 
 	underlying := react.Call("createElement", args...)
 
-	return &H3Def{underlying: underlying}
+	return &H3Elem{Element: elementHolder{elem: underlying}}
 }

--- a/h4.go
+++ b/h4.go
@@ -3,11 +3,9 @@
 
 package react
 
-import "github.com/gopherjs/gopherjs/js"
-
-// H4Def is the React component definition corresponding to the HTML <h4> element
-type H4Def struct {
-	underlying *js.Object
+// H4Elem is the React element definition corresponding to the HTML <h4> element
+type H4Elem struct {
+	Element
 }
 
 // _H4Props defines the properties for the <h4> element
@@ -15,11 +13,9 @@ type _H4Props struct {
 	*BasicHTMLElement
 }
 
-func (d *H4Def) reactElement() {}
-
 // H4 creates a new instance of a <h4> element with the provided props and
-// child
-func H4(props *H4Props, children ...Element) *H4Def {
+// children
+func H4(props *H4Props, children ...Element) *H4Elem {
 
 	rProps := &_H4Props{
 		BasicHTMLElement: newBasicHTMLElement(),
@@ -37,5 +33,5 @@ func H4(props *H4Props, children ...Element) *H4Def {
 
 	underlying := react.Call("createElement", args...)
 
-	return &H4Def{underlying: underlying}
+	return &H4Elem{Element: elementHolder{elem: underlying}}
 }

--- a/hr.go
+++ b/hr.go
@@ -3,11 +3,9 @@
 
 package react
 
-import "github.com/gopherjs/gopherjs/js"
-
-// HRDef is the React component definition corresponding to the HTML <hr> element
-type HRDef struct {
-	underlying *js.Object
+// HRElem is the React element definition corresponding to the HTML <hr> element
+type HRElem struct {
+	Element
 }
 
 // _HRProps defines the properties for the <hr> element
@@ -15,10 +13,8 @@ type _HRProps struct {
 	*BasicHTMLElement
 }
 
-func (d *HRDef) reactElement() {}
-
 // HR creates a new instance of a <hr> element with the provided props
-func HR(props *HRProps) *HRDef {
+func HR(props *HRProps) *HRElem {
 
 	rProps := &_HRProps{
 		BasicHTMLElement: newBasicHTMLElement(),
@@ -30,5 +26,5 @@ func HR(props *HRProps) *HRDef {
 
 	underlying := react.Call("createElement", "hr", rProps)
 
-	return &HRDef{underlying: underlying}
+	return &HRElem{Element: elementHolder{elem: underlying}}
 }

--- a/i.go
+++ b/i.go
@@ -3,11 +3,9 @@
 
 package react
 
-import "github.com/gopherjs/gopherjs/js"
-
-// IDef is the React component definition corresponding to the HTML <i> element
-type IDef struct {
-	underlying *js.Object
+// IElem is the React element definition corresponding to the HTML <i> element
+type IElem struct {
+	Element
 }
 
 // _IProps are the props for a <i> component
@@ -17,10 +15,8 @@ type _IProps struct {
 	Src string `js:"src"`
 }
 
-func (d *IDef) reactElement() {}
-
 // I creates a new instance of a <i> element with the provided props and children
-func I(props *IProps, children ...Element) *IDef {
+func I(props *IProps, children ...Element) *IElem {
 
 	rProps := &_IProps{
 		BasicHTMLElement: newBasicHTMLElement(),
@@ -38,5 +34,5 @@ func I(props *IProps, children ...Element) *IDef {
 
 	underlying := react.Call("createElement", args...)
 
-	return &IDef{underlying: underlying}
+	return &IElem{Element: elementHolder{elem: underlying}}
 }

--- a/img.go
+++ b/img.go
@@ -3,11 +3,9 @@
 
 package react
 
-import "github.com/gopherjs/gopherjs/js"
-
-// ImgDef is the React component definition corresponding to the HTML <Img> element
-type ImgDef struct {
-	underlying *js.Object
+// ImgElem is the React element definition corresponding to the HTML <Img> element
+type ImgElem struct {
+	Element
 }
 
 // _ImgProps are the props for a <Img> component
@@ -17,10 +15,8 @@ type _ImgProps struct {
 	Src string `js:"src"`
 }
 
-func (d *ImgDef) reactElement() {}
-
 // Img creates a new instance of a <Img> element with the provided props and children
-func Img(props *ImgProps, children ...Element) *ImgDef {
+func Img(props *ImgProps, children ...Element) *ImgElem {
 
 	rProps := &_ImgProps{
 		BasicHTMLElement: newBasicHTMLElement(),
@@ -38,5 +34,5 @@ func Img(props *ImgProps, children ...Element) *ImgDef {
 
 	underlying := react.Call("createElement", args...)
 
-	return &ImgDef{underlying: underlying}
+	return &ImgElem{Element: elementHolder{elem: underlying}}
 }

--- a/input.go
+++ b/input.go
@@ -3,11 +3,9 @@
 
 package react
 
-import "github.com/gopherjs/gopherjs/js"
-
-// InputDef is the React component definition corresponding to the HTML <input> element
-type InputDef struct {
-	underlying *js.Object
+// InputElem is the React element definition corresponding to the HTML <input> element
+type InputElem struct {
+	Element
 }
 
 // _InputProps defines the properties for the <input> element
@@ -20,10 +18,8 @@ type _InputProps struct {
 	DefaultValue string `js:"defaultValue" react:"omitempty"`
 }
 
-func (d *InputDef) reactElement() {}
-
 // Input creates a new instance of a <input> element with the provided props
-func Input(props *InputProps) *InputDef {
+func Input(props *InputProps) *InputElem {
 
 	rProps := &_InputProps{
 		BasicHTMLElement: newBasicHTMLElement(),
@@ -37,7 +33,5 @@ func Input(props *InputProps) *InputDef {
 
 	underlying := react.Call("createElement", args...)
 
-	return &InputDef{
-		underlying: underlying,
-	}
+	return &InputElem{Element: elementHolder{elem: underlying}}
 }

--- a/jsx/jsx.go
+++ b/jsx/jsx.go
@@ -17,7 +17,7 @@ import (
 
 // TODO code generate these parse functions
 
-func parseP(n *html.Node) *r.PDef {
+func parseP(n *html.Node) *r.PElem {
 	var kids []r.Element
 
 	// TODO attributes
@@ -29,19 +29,19 @@ func parseP(n *html.Node) *r.PDef {
 	return r.P(nil, kids...)
 }
 
-func parseHR(n *html.Node) *r.HRDef {
+func parseHR(n *html.Node) *r.HRElem {
 	// TODO attributes
 
 	return r.HR(nil)
 }
 
-func parseBR(n *html.Node) *r.BRDef {
+func parseBR(n *html.Node) *r.BRElem {
 	// TODO attributes
 
 	return r.BR(nil)
 }
 
-func parseH1(n *html.Node) *r.H1Def {
+func parseH1(n *html.Node) *r.H1Elem {
 	var kids []r.Element
 
 	// TODO attributes
@@ -53,7 +53,7 @@ func parseH1(n *html.Node) *r.H1Def {
 	return r.H1(nil, kids...)
 }
 
-func parseSpan(n *html.Node) *r.SpanDef {
+func parseSpan(n *html.Node) *r.SpanElem {
 	var kids []r.Element
 
 	var vp *r.SpanProps
@@ -80,7 +80,7 @@ func parseSpan(n *html.Node) *r.SpanDef {
 	return r.Span(vp, kids...)
 }
 
-func parseI(n *html.Node) *r.IDef {
+func parseI(n *html.Node) *r.IElem {
 	var kids []r.Element
 
 	var vp *r.IProps
@@ -107,7 +107,7 @@ func parseI(n *html.Node) *r.IDef {
 	return r.I(vp, kids...)
 }
 
-func parseFooter(n *html.Node) *r.FooterDef {
+func parseFooter(n *html.Node) *r.FooterElem {
 	var kids []r.Element
 
 	var vp *r.FooterProps
@@ -134,7 +134,7 @@ func parseFooter(n *html.Node) *r.FooterDef {
 	return r.Footer(vp, kids...)
 }
 
-func parseDiv(n *html.Node) *r.DivDef {
+func parseDiv(n *html.Node) *r.DivElem {
 	var kids []r.Element
 
 	var vp *r.DivProps
@@ -163,7 +163,7 @@ func parseDiv(n *html.Node) *r.DivDef {
 	return r.Div(vp, kids...)
 }
 
-func parseButton(n *html.Node) *r.ButtonDef {
+func parseButton(n *html.Node) *r.ButtonElem {
 	var kids []r.Element
 
 	var vp *r.ButtonProps
@@ -190,7 +190,7 @@ func parseButton(n *html.Node) *r.ButtonDef {
 	return r.Button(vp, kids...)
 }
 
-func parseCode(n *html.Node) *r.CodeDef {
+func parseCode(n *html.Node) *r.CodeElem {
 	var kids []r.Element
 
 	// TODO attributes
@@ -202,7 +202,7 @@ func parseCode(n *html.Node) *r.CodeDef {
 	return r.Code(nil, kids...)
 }
 
-func parseH3(n *html.Node) *r.H3Def {
+func parseH3(n *html.Node) *r.H3Elem {
 	var kids []r.Element
 
 	// TODO attributes
@@ -214,7 +214,7 @@ func parseH3(n *html.Node) *r.H3Def {
 	return r.H3(nil, kids...)
 }
 
-func parseImg(n *html.Node) *r.ImgDef {
+func parseImg(n *html.Node) *r.ImgElem {
 	var kids []r.Element
 
 	var vp *r.ImgProps
@@ -241,7 +241,7 @@ func parseImg(n *html.Node) *r.ImgDef {
 	return r.Img(vp, kids...)
 }
 
-func parseA(n *html.Node) *r.ADef {
+func parseA(n *html.Node) *r.AElem {
 	var kids []r.Element
 
 	var vp *r.AProps

--- a/label.go
+++ b/label.go
@@ -3,11 +3,9 @@
 
 package react
 
-import "github.com/gopherjs/gopherjs/js"
-
-// LabelDef is the React component definition corresponding to the HTML <label> element
-type LabelDef struct {
-	underlying *js.Object
+// LabelElem is the React element definition corresponding to the HTML <label> element
+type LabelElem struct {
+	Element
 }
 
 // _LabelProps defines the properties for the <label> element
@@ -17,11 +15,9 @@ type _LabelProps struct {
 	For string `js:"htmlFor"`
 }
 
-func (d *LabelDef) reactElement() {}
-
 // Label creates a new instance of a <label> element with the provided props and child
 // element
-func Label(props *LabelProps, child Element) *LabelDef {
+func Label(props *LabelProps, child Element) *LabelElem {
 
 	rProps := &_LabelProps{
 		BasicHTMLElement: newBasicHTMLElement(),
@@ -33,5 +29,5 @@ func Label(props *LabelProps, child Element) *LabelDef {
 
 	underlying := react.Call("createElement", "label", rProps, elementToReactObj(child))
 
-	return &LabelDef{underlying: underlying}
+	return &LabelElem{Element: elementHolder{elem: underlying}}
 }

--- a/li.go
+++ b/li.go
@@ -3,11 +3,9 @@
 
 package react
 
-import "github.com/gopherjs/gopherjs/js"
-
-// LiDef is the React component definition corresponding to the HTML <li> element
-type LiDef struct {
-	underlying *js.Object
+// LiElem is the React element definition corresponding to the HTML <li> element
+type LiElem struct {
+	Element
 }
 
 // _LiProps defines the properties for the <li> element
@@ -15,11 +13,9 @@ type _LiProps struct {
 	*BasicHTMLElement
 }
 
-func (d *LiDef) reactElement() {}
-
 // Li creates a new instance of an <li> element with the provided props
 // and children
-func Li(props *LiProps, children ...Element) *LiDef {
+func Li(props *LiProps, children ...Element) *LiElem {
 
 	rProps := &_LiProps{
 		BasicHTMLElement: newBasicHTMLElement(),
@@ -37,5 +33,5 @@ func Li(props *LiProps, children ...Element) *LiDef {
 
 	underlying := react.Call("createElement", args...)
 
-	return &LiDef{underlying: underlying}
+	return &LiElem{Element: elementHolder{elem: underlying}}
 }

--- a/nav.go
+++ b/nav.go
@@ -3,11 +3,9 @@
 
 package react
 
-import "github.com/gopherjs/gopherjs/js"
-
-// NavDef is the React component definition corresponding to the HTML <nav> element
-type NavDef struct {
-	underlying *js.Object
+// NavElem is the React element definition corresponding to the HTML <nav> element
+type NavElem struct {
+	Element
 }
 
 // _NavProps defines the properties for the <nav> element
@@ -15,10 +13,8 @@ type _NavProps struct {
 	*BasicHTMLElement
 }
 
-func (d *NavDef) reactElement() {}
-
 // Nav creates a new instance of a <nav> element with the provided props and children
-func Nav(props *NavProps, children ...Element) *NavDef {
+func Nav(props *NavProps, children ...Element) *NavElem {
 
 	rProps := &_NavProps{
 		BasicHTMLElement: newBasicHTMLElement(),
@@ -36,5 +32,5 @@ func Nav(props *NavProps, children ...Element) *NavDef {
 
 	underlying := react.Call("createElement", args...)
 
-	return &NavDef{underlying: underlying}
+	return &NavElem{Element: elementHolder{elem: underlying}}
 }

--- a/option.go
+++ b/option.go
@@ -3,11 +3,9 @@
 
 package react
 
-import "github.com/gopherjs/gopherjs/js"
-
-// OptionDef is the React component definition corresponding to the HTML <option> element
-type OptionDef struct {
-	underlying *js.Object
+// OptionElem is the React element definition corresponding to the HTML <option> element
+type OptionElem struct {
+	Element
 }
 
 // _OptionProps defines the properties for the <option> element
@@ -17,10 +15,8 @@ type _OptionProps struct {
 	Value string `js:"value"`
 }
 
-func (d *OptionDef) reactElement() {}
-
 // Option creates a new instance of a <option> element with the provided props
-func Option(props *OptionProps, child Element) *OptionDef {
+func Option(props *OptionProps, child Element) *OptionElem {
 
 	rProps := &_OptionProps{
 		BasicHTMLElement: newBasicHTMLElement(),
@@ -34,7 +30,5 @@ func Option(props *OptionProps, child Element) *OptionDef {
 
 	underlying := react.Call("createElement", args...)
 
-	return &OptionDef{
-		underlying: underlying,
-	}
+	return &OptionElem{Element: elementHolder{elem: underlying}}
 }

--- a/p.go
+++ b/p.go
@@ -3,13 +3,11 @@
 
 package react
 
-import "github.com/gopherjs/gopherjs/js"
-
 //go:generate reactGen
 
-// PDef is the React component definition corresponding to the HTML <p> element
-type PDef struct {
-	underlying *js.Object
+// PElem is the React element definition corresponding to the HTML <p> element
+type PElem struct {
+	Element
 }
 
 // _PProps are the props for a <div> component
@@ -17,11 +15,9 @@ type _PProps struct {
 	*BasicHTMLElement
 }
 
-func (d *PDef) reactElement() {}
-
 // P creates a new instance of a <p> element with the provided props and
 // children
-func P(props *PProps, children ...Element) *PDef {
+func P(props *PProps, children ...Element) *PElem {
 
 	rProps := &_PProps{
 		BasicHTMLElement: newBasicHTMLElement(),
@@ -39,5 +35,5 @@ func P(props *PProps, children ...Element) *PDef {
 
 	underlying := react.Call("createElement", args...)
 
-	return &PDef{underlying: underlying}
+	return &PElem{Element: elementHolder{elem: underlying}}
 }

--- a/pre.go
+++ b/pre.go
@@ -3,11 +3,9 @@
 
 package react
 
-import "github.com/gopherjs/gopherjs/js"
-
-// PreDef is the React component definition corresponding to the HTML <pre> element
-type PreDef struct {
-	underlying *js.Object
+// PreElem is the React element definition corresponding to the HTML <pre> element
+type PreElem struct {
+	Element
 }
 
 // _PreProps defines the properties for the <pre> element
@@ -15,11 +13,9 @@ type _PreProps struct {
 	*BasicHTMLElement
 }
 
-func (d *PreDef) reactElement() {}
-
 // Pre creates a new instance of a <pre> element with the provided props and
 // children
-func Pre(props *PreProps, children ...Element) *PreDef {
+func Pre(props *PreProps, children ...Element) *PreElem {
 
 	rProps := &_PreProps{
 		BasicHTMLElement: newBasicHTMLElement(),
@@ -37,5 +33,5 @@ func Pre(props *PreProps, children ...Element) *PreDef {
 
 	underlying := react.Call("createElement", args...)
 
-	return &PreDef{underlying: underlying}
+	return &PreElem{Element: elementHolder{elem: underlying}}
 }

--- a/select.go
+++ b/select.go
@@ -3,11 +3,9 @@
 
 package react
 
-import "github.com/gopherjs/gopherjs/js"
-
-// SelectDef is the React component definition corresponding to the HTML <select> element
-type SelectDef struct {
-	underlying *js.Object
+// SelectElem is the React element definition corresponding to the HTML <select> element
+type SelectElem struct {
+	Element
 }
 
 // _SelectProps are the props for a <select> component
@@ -17,10 +15,8 @@ type _SelectProps struct {
 	Value string `js:"value"`
 }
 
-func (d *SelectDef) reactElement() {}
-
 // Select creates a new instance of a <select> element with the provided props and children
-func Select(props *SelectProps, children ...*OptionDef) *SelectDef {
+func Select(props *SelectProps, children ...*OptionElem) *SelectElem {
 
 	rProps := &_SelectProps{
 		BasicHTMLElement: newBasicHTMLElement(),
@@ -38,5 +34,5 @@ func Select(props *SelectProps, children ...*OptionDef) *SelectDef {
 
 	underlying := react.Call("createElement", args...)
 
-	return &SelectDef{underlying: underlying}
+	return &SelectElem{Element: elementHolder{elem: underlying}}
 }

--- a/span.go
+++ b/span.go
@@ -3,11 +3,9 @@
 
 package react
 
-import "github.com/gopherjs/gopherjs/js"
-
-// SpanDef is the React component definition corresponding to the HTML <p> element
-type SpanDef struct {
-	underlying *js.Object
+// SpanElem is the React element definition corresponding to the HTML <p> element
+type SpanElem struct {
+	Element
 }
 
 // _SpanProps defines the properties for the <p> element
@@ -15,11 +13,9 @@ type _SpanProps struct {
 	*BasicHTMLElement
 }
 
-func (d *SpanDef) reactElement() {}
-
 // Span creates a new instance of a <p> element with the provided props and
 // children
-func Span(props *SpanProps, children ...Element) *SpanDef {
+func Span(props *SpanProps, children ...Element) *SpanElem {
 
 	rProps := &_SpanProps{
 		BasicHTMLElement: newBasicHTMLElement(),
@@ -37,5 +33,5 @@ func Span(props *SpanProps, children ...Element) *SpanDef {
 
 	underlying := react.Call("createElement", args...)
 
-	return &SpanDef{underlying: underlying}
+	return &SpanElem{Element: elementHolder{elem: underlying}}
 }

--- a/text_area.go
+++ b/text_area.go
@@ -3,11 +3,9 @@
 
 package react
 
-import "github.com/gopherjs/gopherjs/js"
-
-// TextAreaDef is the React component definition corresponding to the HTML <textarea> element
-type TextAreaDef struct {
-	underlying *js.Object
+// TextAreaElem is the React element definition corresponding to the HTML <textarea> element
+type TextAreaElem struct {
+	Element
 }
 
 // _TextAreaProps defines the properties for the <textarea> element
@@ -21,11 +19,9 @@ type _TextAreaProps struct {
 	DefaultValue string `js:"defaultValue" react:"omitempty"`
 }
 
-func (d *TextAreaDef) reactElement() {}
-
 // TextArea creates a new instance of a <textarea> element with the provided props and
 // children
-func TextArea(props *TextAreaProps, children ...Element) *TextAreaDef {
+func TextArea(props *TextAreaProps, children ...Element) *TextAreaElem {
 
 	rProps := &_TextAreaProps{
 		BasicHTMLElement: newBasicHTMLElement(),
@@ -43,5 +39,5 @@ func TextArea(props *TextAreaProps, children ...Element) *TextAreaDef {
 
 	underlying := react.Call("createElement", args...)
 
-	return &TextAreaDef{underlying: underlying}
+	return &TextAreaElem{Element: elementHolder{elem: underlying}}
 }

--- a/ul.go
+++ b/ul.go
@@ -3,11 +3,9 @@
 
 package react
 
-import "github.com/gopherjs/gopherjs/js"
-
-// UlDef is the React component definition corresponding to the HTML <ul> element
-type UlDef struct {
-	underlying *js.Object
+// UlElem is the React element definition corresponding to the HTML <ul> element
+type UlElem struct {
+	Element
 }
 
 // _UlProps defines the properties for the <ul> element
@@ -15,11 +13,9 @@ type _UlProps struct {
 	*BasicHTMLElement
 }
 
-func (d *UlDef) reactElement() {}
-
 // Ul creates a new instance of a <ul> element with the provided props and <li>
 // children
-func Ul(props *UlProps, children ...*LiDef) *UlDef {
+func Ul(props *UlProps, children ...*LiElem) *UlElem {
 
 	rProps := &_UlProps{
 		BasicHTMLElement: newBasicHTMLElement(),
@@ -37,5 +33,5 @@ func Ul(props *UlProps, children ...*LiDef) *UlDef {
 
 	underlying := react.Call("createElement", args...)
 
-	return &UlDef{underlying: underlying}
+	return &UlElem{Element: elementHolder{elem: underlying}}
 }


### PR DESCRIPTION
### !! BREAKING CHANGE !!

One of the shortcuts I had taken until this point was to conflate the concept of a component (definition) and an element. This PR introduces the concept of an element. More precise definitions to follow in the wiki, but briefly:

* a component is as it was before, and corresponds directly to a React component. It is the definition, potentially with props and state, of a thing that `Render`'s
* an element is an "instance" of a component (this definition needs to improve... to mention mounting etc)

This has the nice side effect of resolving many of the spurious re-`Render`'s that were happening.

So changes in this PR include:

* Introduced elements and refactored existing components to reflect that change. For core components, e.g. the component behind the `<div>` HTML element, we no longer declare `*Def` component; instead the constructor functions, e.g. `react.Div(...)` return an element, in this case `react.DivElement`
* `react.BlessElement` is now `react.CreateElement`
* Declaring your own component, e.g. `MyCompDef`, requires that methods be declared on the type `MyCompDef` and _not_ `*MyCompDef` (docs to follow)
* Various refactors of methods in `myitcv.io/react`

Less interesting:

* Vendored `github.com/gopherjs/jsbuiltin`