### PR TITLE
Automatically generate buildXElem functions to save boilerplate

### DIFF
--- a/cmd/reactGen/comp_gen.go
+++ b/cmd/reactGen/comp_gen.go
@@ -236,6 +236,12 @@ func build{{.Name}}(cd react.ComponentDef) react.Component {
 	return {{.Name}}Def{ComponentDef: cd}
 }
 
+func build{{.Name}}Elem({{if .HasProps}}props {{.Name}}Props,{{end}} children ...react.Element) *{{.Name}}Elem {
+	return &{{.Name}}Elem{
+		Element: react.CreateElement(build{{.Name}}, {{if .HasProps}}props{{else}}nil{{end}}),
+	}
+}
+
 {{if .HasState}}
 // SetState is an auto-generated proxy proxy to update the state for the
 // {{.Name}} component.  SetState does not immediately mutate {{.Recv}}.State()

--- a/cmd/reactGen/init.go
+++ b/cmd/reactGen/init.go
@@ -84,7 +84,7 @@ type AppDef struct {
 }
 
 func App() *AppElem {
-	return &AppElem{Element: r.CreateElement(buildApp, nil)}
+	return buildAppElem()
 }
 
 func (a AppDef) Render() r.Element {

--- a/components/imm/gen_Select_reactGen.go
+++ b/components/imm/gen_Select_reactGen.go
@@ -23,6 +23,12 @@ func buildSelect(cd react.ComponentDef) react.Component {
 	return SelectDef{ComponentDef: cd}
 }
 
+func buildSelectElem(props SelectProps, children ...react.Element) *SelectElem {
+	return &SelectElem{
+		Element: react.CreateElement(buildSelect, props),
+	}
+}
+
 // SetState is an auto-generated proxy proxy to update the state for the
 // Select component.  SetState does not immediately mutate s.State()
 // but creates a pending state transition.

--- a/components/imm/select.go
+++ b/components/imm/select.go
@@ -61,7 +61,7 @@ type _Imm_entriesKeysSelect []entryKey
 // Select creates a new instance of the SelectDef component with the provided props
 //
 func Select(props SelectProps) *SelectElem {
-	return &SelectElem{Element: r.CreateElement(buildSelect, props)}
+	return buildSelectElem(props)
 }
 
 func (p SelectDef) ComponentWillMount() {

--- a/examples/blog/2017_04_16/app.go
+++ b/examples/blog/2017_04_16/app.go
@@ -11,7 +11,7 @@ type AppDef struct {
 }
 
 func App() *AppElem {
-	return &AppElem{Element: r.CreateElement(buildApp, nil)}
+	return buildAppElem()
 }
 
 func (a AppDef) Render() r.Element {

--- a/examples/blog/2017_04_16/foo_bar.go
+++ b/examples/blog/2017_04_16/foo_bar.go
@@ -41,7 +41,7 @@ type FooBarState struct {
 //
 func FooBar(p FooBarProps) *FooBarElem {
 	// every component constructor must call this function
-	return &FooBarElem{Element: r.CreateElement(buildFooBar, p)}
+	return buildFooBarElem(p)
 }
 
 // Render is a required method on all React components. Notice that the method

--- a/examples/blog/2017_04_16/gen_App_reactGen.go
+++ b/examples/blog/2017_04_16/gen_App_reactGen.go
@@ -17,3 +17,9 @@ func (a AppDef) ShouldComponentUpdateIntf(nextProps, prevState, nextState interf
 func buildApp(cd react.ComponentDef) react.Component {
 	return AppDef{ComponentDef: cd}
 }
+
+func buildAppElem(children ...react.Element) *AppElem {
+	return &AppElem{
+		Element: react.CreateElement(buildApp, nil),
+	}
+}

--- a/examples/blog/2017_04_16/gen_FooBar_reactGen.go
+++ b/examples/blog/2017_04_16/gen_FooBar_reactGen.go
@@ -23,6 +23,12 @@ func buildFooBar(cd react.ComponentDef) react.Component {
 	return FooBarDef{ComponentDef: cd}
 }
 
+func buildFooBarElem(props FooBarProps, children ...react.Element) *FooBarElem {
+	return &FooBarElem{
+		Element: react.CreateElement(buildFooBar, props),
+	}
+}
+
 // SetState is an auto-generated proxy proxy to update the state for the
 // FooBar component.  SetState does not immediately mutate f.State()
 // but creates a pending state transition.

--- a/examples/examples.go
+++ b/examples/examples.go
@@ -31,7 +31,7 @@ const (
 
 // Examples creates instances of the Examples component
 func Examples() *ExamplesElem {
-	return &ExamplesElem{Element: r.CreateElement(buildExamples, nil)}
+	return buildExamplesElem()
 }
 
 type (

--- a/examples/gen_Examples_reactGen.go
+++ b/examples/gen_Examples_reactGen.go
@@ -20,6 +20,12 @@ func buildExamples(cd react.ComponentDef) react.Component {
 	return ExamplesDef{ComponentDef: cd}
 }
 
+func buildExamplesElem(children ...react.Element) *ExamplesElem {
+	return &ExamplesElem{
+		Element: react.CreateElement(buildExamples, nil),
+	}
+}
+
 // SetState is an auto-generated proxy proxy to update the state for the
 // Examples component.  SetState does not immediately mutate e.State()
 // but creates a pending state transition.

--- a/examples/gen_GlobalStateExamples_reactGen.go
+++ b/examples/gen_GlobalStateExamples_reactGen.go
@@ -20,6 +20,12 @@ func buildGlobalStateExamples(cd react.ComponentDef) react.Component {
 	return GlobalStateExamplesDef{ComponentDef: cd}
 }
 
+func buildGlobalStateExamplesElem(children ...react.Element) *GlobalStateExamplesElem {
+	return &GlobalStateExamplesElem{
+		Element: react.CreateElement(buildGlobalStateExamples, nil),
+	}
+}
+
 // SetState is an auto-generated proxy proxy to update the state for the
 // GlobalStateExamples component.  SetState does not immediately mutate g.State()
 // but creates a pending state transition.

--- a/examples/gen_ImmExamples_reactGen.go
+++ b/examples/gen_ImmExamples_reactGen.go
@@ -20,6 +20,12 @@ func buildImmExamples(cd react.ComponentDef) react.Component {
 	return ImmExamplesDef{ComponentDef: cd}
 }
 
+func buildImmExamplesElem(children ...react.Element) *ImmExamplesElem {
+	return &ImmExamplesElem{
+		Element: react.CreateElement(buildImmExamples, nil),
+	}
+}
+
 // SetState is an auto-generated proxy proxy to update the state for the
 // ImmExamples component.  SetState does not immediately mutate i.State()
 // but creates a pending state transition.

--- a/examples/global_state_examples.go
+++ b/examples/global_state_examples.go
@@ -12,7 +12,7 @@ type GlobalStateExamplesDef struct {
 
 // GlobalStateExamples creates instances of the GlobalStateExamples component
 func GlobalStateExamples() *GlobalStateExamplesElem {
-	return &GlobalStateExamplesElem{Element: r.CreateElement(buildGlobalStateExamples, nil)}
+	return buildGlobalStateExamplesElem()
 }
 
 // GlobalStateExamplesState is the state type for the GlobalStateExamples component

--- a/examples/hellomessage/gen_HelloMessage_reactGen.go
+++ b/examples/hellomessage/gen_HelloMessage_reactGen.go
@@ -21,6 +21,12 @@ func buildHelloMessage(cd react.ComponentDef) react.Component {
 	return HelloMessageDef{ComponentDef: cd}
 }
 
+func buildHelloMessageElem(props HelloMessageProps, children ...react.Element) *HelloMessageElem {
+	return &HelloMessageElem{
+		Element: react.CreateElement(buildHelloMessage, props),
+	}
+}
+
 // Props is an auto-generated proxy to the current props of HelloMessage
 func (h HelloMessageDef) Props() HelloMessageProps {
 	uprops := h.ComponentDef.Props()

--- a/examples/imm_examples.go
+++ b/examples/imm_examples.go
@@ -15,7 +15,7 @@ type ImmExamplesDef struct {
 
 // ImmExamples creates instances of the ImmExamples component
 func ImmExamples() *ImmExamplesElem {
-	return &ImmExamplesElem{Element: r.CreateElement(buildImmExamples, nil)}
+	return buildImmExamplesElem()
 }
 
 // ImmExamplesState is the state type for the ImmExamples component

--- a/examples/immtodoapp/gen_TodoApp_reactGen.go
+++ b/examples/immtodoapp/gen_TodoApp_reactGen.go
@@ -20,6 +20,12 @@ func buildTodoApp(cd react.ComponentDef) react.Component {
 	return TodoAppDef{ComponentDef: cd}
 }
 
+func buildTodoAppElem(children ...react.Element) *TodoAppElem {
+	return &TodoAppElem{
+		Element: react.CreateElement(buildTodoApp, nil),
+	}
+}
+
 // SetState is an auto-generated proxy proxy to update the state for the
 // TodoApp component.  SetState does not immediately mutate t.State()
 // but creates a pending state transition.

--- a/examples/immtodoapp/todo_app.go
+++ b/examples/immtodoapp/todo_app.go
@@ -29,7 +29,7 @@ type TodoAppState struct {
 
 // TodoApp creates instances of the TodoApp component
 func TodoApp() *TodoAppElem {
-	return &TodoAppElem{Element: r.CreateElement(buildTodoApp, nil)}
+	return buildTodoAppElem()
 }
 
 func (t TodoAppDef) GetInitialState() TodoAppState {

--- a/examples/markdowneditor/gen_MarkdownEditor_reactGen.go
+++ b/examples/markdowneditor/gen_MarkdownEditor_reactGen.go
@@ -20,6 +20,12 @@ func buildMarkdownEditor(cd react.ComponentDef) react.Component {
 	return MarkdownEditorDef{ComponentDef: cd}
 }
 
+func buildMarkdownEditorElem(children ...react.Element) *MarkdownEditorElem {
+	return &MarkdownEditorElem{
+		Element: react.CreateElement(buildMarkdownEditor, nil),
+	}
+}
+
 // SetState is an auto-generated proxy proxy to update the state for the
 // MarkdownEditor component.  SetState does not immediately mutate m.State()
 // but creates a pending state transition.

--- a/examples/markdowneditor/markdown_editor.go
+++ b/examples/markdowneditor/markdown_editor.go
@@ -21,7 +21,7 @@ type MarkdownEditorState struct {
 
 // MarkdownEditor creates instances of the MarkdownEditor component
 func MarkdownEditor() *MarkdownEditorElem {
-	return &MarkdownEditorElem{Element: r.CreateElement(buildMarkdownEditor, nil)}
+	return buildMarkdownEditorElem()
 }
 
 // GetInitialState returns the initial state for a MarkdownEditor component

--- a/examples/sites/examplesshowcase/app.go
+++ b/examples/sites/examplesshowcase/app.go
@@ -22,7 +22,7 @@ type AppState struct {
 }
 
 func App() *AppElem {
-	return &AppElem{Element: r.CreateElement(buildApp, nil)}
+	return buildAppElem()
 }
 
 func (a AppDef) Render() r.Element {

--- a/examples/sites/examplesshowcase/gen_App_reactGen.go
+++ b/examples/sites/examplesshowcase/gen_App_reactGen.go
@@ -20,6 +20,12 @@ func buildApp(cd react.ComponentDef) react.Component {
 	return AppDef{ComponentDef: cd}
 }
 
+func buildAppElem(children ...react.Element) *AppElem {
+	return &AppElem{
+		Element: react.CreateElement(buildApp, nil),
+	}
+}
+
 // SetState is an auto-generated proxy proxy to update the state for the
 // App component.  SetState does not immediately mutate a.State()
 // but creates a pending state transition.

--- a/examples/sites/globalstate/app.go
+++ b/examples/sites/globalstate/app.go
@@ -14,7 +14,7 @@ type AppState struct {
 }
 
 func App() *AppElem {
-	return &AppElem{Element: r.CreateElement(buildApp, nil)}
+	return buildAppElem()
 }
 
 func (a AppDef) Render() r.Element {

--- a/examples/sites/globalstate/gen_App_reactGen.go
+++ b/examples/sites/globalstate/gen_App_reactGen.go
@@ -20,6 +20,12 @@ func buildApp(cd react.ComponentDef) react.Component {
 	return AppDef{ComponentDef: cd}
 }
 
+func buildAppElem(children ...react.Element) *AppElem {
+	return &AppElem{
+		Element: react.CreateElement(buildApp, nil),
+	}
+}
+
 // SetState is an auto-generated proxy proxy to update the state for the
 // App component.  SetState does not immediately mutate a.State()
 // but creates a pending state transition.

--- a/examples/sites/globalstate/gen_PersonChooser_reactGen.go
+++ b/examples/sites/globalstate/gen_PersonChooser_reactGen.go
@@ -23,6 +23,12 @@ func buildPersonChooser(cd react.ComponentDef) react.Component {
 	return PersonChooserDef{ComponentDef: cd}
 }
 
+func buildPersonChooserElem(props PersonChooserProps, children ...react.Element) *PersonChooserElem {
+	return &PersonChooserElem{
+		Element: react.CreateElement(buildPersonChooser, props),
+	}
+}
+
 // SetState is an auto-generated proxy proxy to update the state for the
 // PersonChooser component.  SetState does not immediately mutate p.State()
 // but creates a pending state transition.

--- a/examples/sites/globalstate/gen_PersonViewer_reactGen.go
+++ b/examples/sites/globalstate/gen_PersonViewer_reactGen.go
@@ -20,6 +20,12 @@ func buildPersonViewer(cd react.ComponentDef) react.Component {
 	return PersonViewerDef{ComponentDef: cd}
 }
 
+func buildPersonViewerElem(children ...react.Element) *PersonViewerElem {
+	return &PersonViewerElem{
+		Element: react.CreateElement(buildPersonViewer, nil),
+	}
+}
+
 // SetState is an auto-generated proxy proxy to update the state for the
 // PersonViewer component.  SetState does not immediately mutate p.State()
 // but creates a pending state transition.

--- a/examples/sites/globalstate/person_chooser.go
+++ b/examples/sites/globalstate/person_chooser.go
@@ -30,7 +30,7 @@ type PersonChooserState struct {
 }
 
 func PersonChooser(props PersonChooserProps) *PersonChooserElem {
-	return &PersonChooserElem{Element: r.CreateElement(buildPersonChooser, props)}
+	return buildPersonChooserElem(props)
 }
 
 func (p PersonChooserDef) ComponentWillMount() {

--- a/examples/sites/globalstate/person_viewer.go
+++ b/examples/sites/globalstate/person_viewer.go
@@ -19,7 +19,7 @@ type PersonViewerState struct {
 }
 
 func PersonViewer() *PersonViewerElem {
-	return &PersonViewerElem{Element: r.CreateElement(buildPersonViewer, nil)}
+	return buildPersonViewerElem()
 }
 
 func (p PersonViewerDef) ComponentWillMount() {

--- a/examples/sites/helloworld/app.go
+++ b/examples/sites/helloworld/app.go
@@ -11,7 +11,7 @@ type AppDef struct {
 }
 
 func App() *AppElem {
-	return &AppElem{Element: r.CreateElement(buildApp, nil)}
+	return buildAppElem()
 }
 
 func (a AppDef) Render() r.Element {

--- a/examples/sites/helloworld/gen_App_reactGen.go
+++ b/examples/sites/helloworld/gen_App_reactGen.go
@@ -17,3 +17,9 @@ func (a AppDef) ShouldComponentUpdateIntf(nextProps, prevState, nextState interf
 func buildApp(cd react.ComponentDef) react.Component {
 	return AppDef{ComponentDef: cd}
 }
+
+func buildAppElem(children ...react.Element) *AppElem {
+	return &AppElem{
+		Element: react.CreateElement(buildApp, nil),
+	}
+}

--- a/examples/sites/latency/app.go
+++ b/examples/sites/latency/app.go
@@ -16,7 +16,7 @@ type AppDef struct {
 }
 
 func App() *AppElem {
-	return &AppElem{Element: r.CreateElement(buildApp, nil)}
+	return buildAppElem()
 }
 
 func (a AppDef) Render() r.Element {

--- a/examples/sites/latency/gen_App_reactGen.go
+++ b/examples/sites/latency/gen_App_reactGen.go
@@ -17,3 +17,9 @@ func (a AppDef) ShouldComponentUpdateIntf(nextProps, prevState, nextState interf
 func buildApp(cd react.ComponentDef) react.Component {
 	return AppDef{ComponentDef: cd}
 }
+
+func buildAppElem(children ...react.Element) *AppElem {
+	return &AppElem{
+		Element: react.CreateElement(buildApp, nil),
+	}
+}

--- a/examples/sites/latency/gen_Latency_reactGen.go
+++ b/examples/sites/latency/gen_Latency_reactGen.go
@@ -20,6 +20,12 @@ func buildLatency(cd react.ComponentDef) react.Component {
 	return LatencyDef{ComponentDef: cd}
 }
 
+func buildLatencyElem(children ...react.Element) *LatencyElem {
+	return &LatencyElem{
+		Element: react.CreateElement(buildLatency, nil),
+	}
+}
+
 // SetState is an auto-generated proxy proxy to update the state for the
 // Latency component.  SetState does not immediately mutate l.State()
 // but creates a pending state transition.

--- a/examples/sites/latency/latency.go
+++ b/examples/sites/latency/latency.go
@@ -59,7 +59,7 @@ type LatencyState struct {
 }
 
 func Latency() *LatencyElem {
-	return &LatencyElem{Element: r.CreateElement(buildLatency, nil)}
+	return buildLatencyElem()
 }
 
 func (l LatencyDef) Render() r.Element {

--- a/examples/timer/gen_Timer_reactGen.go
+++ b/examples/timer/gen_Timer_reactGen.go
@@ -20,6 +20,12 @@ func buildTimer(cd react.ComponentDef) react.Component {
 	return TimerDef{ComponentDef: cd}
 }
 
+func buildTimerElem(children ...react.Element) *TimerElem {
+	return &TimerElem{
+		Element: react.CreateElement(buildTimer, nil),
+	}
+}
+
 // SetState is an auto-generated proxy proxy to update the state for the
 // Timer component.  SetState does not immediately mutate t.State()
 // but creates a pending state transition.

--- a/examples/timer/timer.go
+++ b/examples/timer/timer.go
@@ -23,7 +23,7 @@ type TimerState struct {
 
 // Timer creates instances of the Timer component
 func Timer() *TimerElem {
-	return &TimerElem{Element: r.CreateElement(buildTimer, nil)}
+	return buildTimerElem()
 }
 
 // ComponentWillMount is a React lifecycle method for the Timer component

--- a/examples/todoapp/gen_TodoApp_reactGen.go
+++ b/examples/todoapp/gen_TodoApp_reactGen.go
@@ -20,6 +20,12 @@ func buildTodoApp(cd react.ComponentDef) react.Component {
 	return TodoAppDef{ComponentDef: cd}
 }
 
+func buildTodoAppElem(children ...react.Element) *TodoAppElem {
+	return &TodoAppElem{
+		Element: react.CreateElement(buildTodoApp, nil),
+	}
+}
+
 // SetState is an auto-generated proxy proxy to update the state for the
 // TodoApp component.  SetState does not immediately mutate t.State()
 // but creates a pending state transition.

--- a/examples/todoapp/todo_app.go
+++ b/examples/todoapp/todo_app.go
@@ -22,7 +22,7 @@ type TodoAppState struct {
 
 // TodoApp creates instances of the TodoApp component
 func TodoApp() *TodoAppElem {
-	return &TodoAppElem{Element: r.CreateElement(buildTodoApp, nil)}
+	return buildTodoAppElem()
 }
 
 // Equals must be defined because struct val instances of TodoAppState cannot


### PR DESCRIPTION
Compare the old:

```go

func Timer() *TimerElem {
	return &TimerElem{Element: r.CreateElement(buildTimer, nil)}
}
```

vs the new:

```go
func Timer() *TimerElem {
	return buildTimerElem()
}
```

Much cleaner. Is also props-aware, so requires props (of correct type) when they are defined.