### PR TITLE
Make github ribbon optional in examples

### DIFF
--- a/a_elem.go
+++ b/a_elem.go
@@ -12,6 +12,7 @@ type AElem struct {
 type _AProps struct {
 	*BasicHTMLElement
 
+	Title  string `js:"title"`
 	Target string `js:"target"`
 	Href   string `js:"href"`
 }

--- a/examples/sites/globalstate/index.html
+++ b/examples/sites/globalstate/index.html
@@ -18,7 +18,6 @@
     <link rel="stylesheet" href="../common/gh-fork-ribbon.min.css" />
   </head>
   <body>
-    <a class="github-fork-ribbon right-top" target="_blank" href="https://github.com/myitcv/react/blob/master/examples/sites/globalstate/app.go" title="Source on GitHub">Source on GitHub</a>
     <div id="app"></div>
     <script src="globalstate.js"></script>
   </body>

--- a/examples/sites/globalstate/main.go
+++ b/examples/sites/globalstate/main.go
@@ -4,6 +4,8 @@
 package main
 
 import (
+	"net/url"
+
 	"myitcv.io/react"
 	"myitcv.io/react/examples/sites/globalstate/model"
 	"myitcv.io/react/examples/sites/globalstate/state"
@@ -13,10 +15,33 @@ import (
 
 //go:generate reactGen
 
-var document = dom.GetWindow().Document()
+var document = dom.GetWindow().Document().(dom.HTMLDocument)
 
 func main() {
 	domTarget := document.GetElementByID("app")
+
+	u, err := url.Parse(document.URL())
+	if err != nil {
+		panic(err)
+	}
+
+	var elems []react.Element
+
+	if u.Query().Get("hideGithubRibbon") != "true" {
+		a := react.A(
+			&react.AProps{
+				ClassName: "github-fork-ribbon right-top",
+				Target:    "_blank",
+				Href:      "https://github.com/myitcv/react/blob/master/examples/sites/globalstate/main.go",
+				Title:     "Source on GitHub",
+			},
+			react.S("Source on GitHub"),
+		)
+
+		elems = append(elems, a)
+	}
+
+	elems = append(elems, App())
 
 	state.State.Root().People().Set(model.NewPeople(
 		model.NewPerson("Peter", 50),
@@ -24,5 +49,5 @@ func main() {
 		model.NewPerson("Mary", 52),
 	))
 
-	react.Render(App(), domTarget)
+	react.Render(react.Div(nil, elems...), domTarget)
 }

--- a/examples/sites/hellomessage/index.html
+++ b/examples/sites/hellomessage/index.html
@@ -18,7 +18,6 @@
     <link rel="stylesheet" href="../common/gh-fork-ribbon.min.css" />
   </head>
   <body>
-    <a class="github-fork-ribbon right-top" target="_blank" href="https://github.com/myitcv/react/blob/master/examples/sites/hellomessage/main.go" title="Source on GitHub">Source on GitHub</a>
     <div class="container">
       <div id="hellomessage"></div>
     </div>

--- a/examples/sites/hellomessage/main.go
+++ b/examples/sites/hellomessage/main.go
@@ -4,22 +4,45 @@
 package main
 
 import (
+	"net/url"
+
 	"myitcv.io/react"
 	"myitcv.io/react/examples/hellomessage"
 
 	"honnef.co/go/js/dom"
 )
 
-var document = dom.GetWindow().Document()
+var document = dom.GetWindow().Document().(dom.HTMLDocument)
 
 func main() {
 	domTarget := document.GetElementByID("hellomessage")
+
+	u, err := url.Parse(document.URL())
+	if err != nil {
+		panic(err)
+	}
+
+	var elems []react.Element
+
+	if u.Query().Get("hideGithubRibbon") != "true" {
+		a := react.A(
+			&react.AProps{
+				ClassName: "github-fork-ribbon right-top",
+				Target:    "_blank",
+				Href:      "https://github.com/myitcv/react/blob/master/examples/sites/timer/main.go",
+				Title:     "Source on GitHub",
+			},
+			react.S("Source on GitHub"),
+		)
+
+		elems = append(elems, a)
+	}
 
 	props := hellomessage.HelloMessageProps{
 		Name: "Jane",
 	}
 
-	examples := hellomessage.HelloMessage(props)
+	elems = append(elems, hellomessage.HelloMessage(props))
 
-	react.Render(examples, domTarget)
+	react.Render(react.Div(nil, elems...), domTarget)
 }

--- a/examples/sites/immtodoapp/index.html
+++ b/examples/sites/immtodoapp/index.html
@@ -18,7 +18,6 @@
     <link rel="stylesheet" href="../common/gh-fork-ribbon.min.css" />
   </head>
   <body>
-    <a class="github-fork-ribbon right-top" target="_blank" href="https://github.com/myitcv/react/blob/master/examples/sites/immtodoapp/main.go" title="Source on GitHub">Source on GitHub</a>
     <div class="container">
       <div id="immtodoapp"></div>
     </div>

--- a/examples/sites/immtodoapp/main.go
+++ b/examples/sites/immtodoapp/main.go
@@ -4,18 +4,42 @@
 package main
 
 import (
+	"net/url"
+
 	"myitcv.io/react"
 	"myitcv.io/react/examples/immtodoapp"
 
 	"honnef.co/go/js/dom"
 )
 
-var document = dom.GetWindow().Document()
+var document = dom.GetWindow().Document().(dom.HTMLDocument)
 
 func main() {
 	domTarget := document.GetElementByID("immtodoapp")
 
-	examples := immtodoapp.TodoApp()
+	u, err := url.Parse(document.URL())
+	if err != nil {
+		panic(err)
+	}
 
-	react.Render(examples, domTarget)
+	var elems []react.Element
+
+	if u.Query().Get("hideGithubRibbon") != "true" {
+		a := react.A(
+			&react.AProps{
+				ClassName: "github-fork-ribbon right-top",
+				Target:    "_blank",
+				Href:      "https://github.com/myitcv/react/blob/master/examples/sites/immtodoapp/main.go",
+				Title:     "Source on GitHub",
+			},
+			react.S("Source on GitHub"),
+		)
+
+		elems = append(elems, a)
+	}
+
+	elems = append(elems, immtodoapp.TodoApp())
+
+	react.Render(react.Div(nil, elems...), domTarget)
+
 }

--- a/examples/sites/latency/index.html
+++ b/examples/sites/latency/index.html
@@ -10,7 +10,6 @@
     <link rel="stylesheet" href="style.css">
   </head>
   <body>
-    <a class="github-fork-ribbon right-top" target="_blank" href="https://github.com/myitcv/react/blob/master/examples/sites/latency/latency.go" title="Source on GitHub">Source on GitHub</a>
     <div id="app"></div>
     <script src="latency.js"></script>
   </body>

--- a/examples/sites/latency/main.go
+++ b/examples/sites/latency/main.go
@@ -4,6 +4,8 @@
 package main
 
 import (
+	"net/url"
+
 	"myitcv.io/react"
 
 	"honnef.co/go/js/dom"
@@ -11,10 +13,33 @@ import (
 
 //go:generate reactGen
 
-var document = dom.GetWindow().Document()
+var document = dom.GetWindow().Document().(dom.HTMLDocument)
 
 func main() {
 	domTarget := document.GetElementByID("app")
 
-	react.Render(App(), domTarget)
+	u, err := url.Parse(document.URL())
+	if err != nil {
+		panic(err)
+	}
+
+	var elems []react.Element
+
+	if u.Query().Get("hideGithubRibbon") != "true" {
+		a := react.A(
+			&react.AProps{
+				ClassName: "github-fork-ribbon right-top",
+				Target:    "_blank",
+				Href:      "https://github.com/myitcv/react/blob/master/examples/sites/latency/main.go",
+				Title:     "Source on GitHub",
+			},
+			react.S("Source on GitHub"),
+		)
+
+		elems = append(elems, a)
+	}
+
+	elems = append(elems, Latency())
+
+	react.Render(react.Div(nil, elems...), domTarget)
 }

--- a/examples/sites/markdowneditor/index.html
+++ b/examples/sites/markdowneditor/index.html
@@ -18,7 +18,6 @@
     <link rel="stylesheet" href="../common/gh-fork-ribbon.min.css" />
   </head>
   <body>
-    <a class="github-fork-ribbon right-top" target="_blank" href="https://github.com/myitcv/react/blob/master/examples/sites/markdowneditor/main.go" title="Source on GitHub">Source on GitHub</a>
     <div class="container">
       <div id="markdowneditor"></div>
     </div>

--- a/examples/sites/markdowneditor/main.go
+++ b/examples/sites/markdowneditor/main.go
@@ -4,18 +4,41 @@
 package main
 
 import (
+	"net/url"
+
 	"myitcv.io/react"
 	"myitcv.io/react/examples/markdowneditor"
 
 	"honnef.co/go/js/dom"
 )
 
-var document = dom.GetWindow().Document()
+var document = dom.GetWindow().Document().(dom.HTMLDocument)
 
 func main() {
 	domTarget := document.GetElementByID("markdowneditor")
 
-	examples := markdowneditor.MarkdownEditor()
+	u, err := url.Parse(document.URL())
+	if err != nil {
+		panic(err)
+	}
 
-	react.Render(examples, domTarget)
+	var elems []react.Element
+
+	if u.Query().Get("hideGithubRibbon") != "true" {
+		a := react.A(
+			&react.AProps{
+				ClassName: "github-fork-ribbon right-top",
+				Target:    "_blank",
+				Href:      "https://github.com/myitcv/react/blob/master/examples/sites/markdowneditor/main.go",
+				Title:     "Source on GitHub",
+			},
+			react.S("Source on GitHub"),
+		)
+
+		elems = append(elems, a)
+	}
+
+	elems = append(elems, markdowneditor.MarkdownEditor())
+
+	react.Render(react.Div(nil, elems...), domTarget)
 }

--- a/examples/sites/timer/index.html
+++ b/examples/sites/timer/index.html
@@ -18,7 +18,6 @@
     <link rel="stylesheet" href="../common/gh-fork-ribbon.min.css" />
   </head>
   <body>
-    <a class="github-fork-ribbon right-top" target="_blank" href="https://github.com/myitcv/react/blob/master/examples/sites/timer/main.go" title="Source on GitHub">Source on GitHub</a>
     <div class="container">
       <div id="timer"></div>
     </div>

--- a/examples/sites/timer/main.go
+++ b/examples/sites/timer/main.go
@@ -4,18 +4,41 @@
 package main
 
 import (
+	"net/url"
+
 	"myitcv.io/react"
 	"myitcv.io/react/examples/timer"
 
 	"honnef.co/go/js/dom"
 )
 
-var document = dom.GetWindow().Document()
+var document = dom.GetWindow().Document().(dom.HTMLDocument)
 
 func main() {
 	domTarget := document.GetElementByID("timer")
 
-	examples := timer.Timer()
+	u, err := url.Parse(document.URL())
+	if err != nil {
+		panic(err)
+	}
 
-	react.Render(examples, domTarget)
+	var elems []react.Element
+
+	if u.Query().Get("hideGithubRibbon") != "true" {
+		a := react.A(
+			&react.AProps{
+				ClassName: "github-fork-ribbon right-top",
+				Target:    "_blank",
+				Href:      "https://github.com/myitcv/react/blob/master/examples/sites/timer/main.go",
+				Title:     "Source on GitHub",
+			},
+			react.S("Source on GitHub"),
+		)
+
+		elems = append(elems, a)
+	}
+
+	elems = append(elems, timer.Timer())
+
+	react.Render(react.Div(nil, elems...), domTarget)
 }

--- a/examples/sites/todoapp/index.html
+++ b/examples/sites/todoapp/index.html
@@ -18,7 +18,6 @@
     <link rel="stylesheet" href="../common/gh-fork-ribbon.min.css" />
   </head>
   <body>
-    <a class="github-fork-ribbon right-top" target="_blank" href="https://github.com/myitcv/react/blob/master/examples/sites/todoapp/main.go" title="Source on GitHub">Source on GitHub</a>
     <div class="container">
       <div id="todoapp"></div>
     </div>

--- a/examples/sites/todoapp/main.go
+++ b/examples/sites/todoapp/main.go
@@ -4,18 +4,41 @@
 package main
 
 import (
+	"net/url"
+
 	"myitcv.io/react"
 	"myitcv.io/react/examples/todoapp"
 
 	"honnef.co/go/js/dom"
 )
 
-var document = dom.GetWindow().Document()
+var document = dom.GetWindow().Document().(dom.HTMLDocument)
 
 func main() {
 	domTarget := document.GetElementByID("todoapp")
 
-	examples := todoapp.TodoApp()
+	u, err := url.Parse(document.URL())
+	if err != nil {
+		panic(err)
+	}
 
-	react.Render(examples, domTarget)
+	var elems []react.Element
+
+	if u.Query().Get("hideGithubRibbon") != "true" {
+		a := react.A(
+			&react.AProps{
+				ClassName: "github-fork-ribbon right-top",
+				Target:    "_blank",
+				Href:      "https://github.com/myitcv/react/blob/master/examples/sites/todoapp/main.go",
+				Title:     "Source on GitHub",
+			},
+			react.S("Source on GitHub"),
+		)
+
+		elems = append(elems, a)
+	}
+
+	elems = append(elems, todoapp.TodoApp())
+
+	react.Render(react.Div(nil, elems...), domTarget)
 }

--- a/gen_AProps_reactGen.go
+++ b/gen_AProps_reactGen.go
@@ -16,6 +16,7 @@ type AProps struct {
 	Role   string
 	Style  *CSS
 	Target string
+	Title  string
 }
 
 func (a *AProps) assign(v *_AProps) {
@@ -49,5 +50,7 @@ func (a *AProps) assign(v *_AProps) {
 	v.Style = a.Style.hack()
 
 	v.Target = a.Target
+
+	v.Title = a.Title
 
 }


### PR DESCRIPTION
Means examples can then be embedded in slides without a horrid banner appearing on each page