### PR TITLE
Do not use React setState

### DIFF
--- a/cmd/reactGen/comp_gen.go
+++ b/cmd/reactGen/comp_gen.go
@@ -212,26 +212,6 @@ type {{.Name}}Elem struct {
 	react.Element
 }
 
-func ({{.Recv}} {{.Name}}Def) ShouldComponentUpdateIntf(nextProps react.Props, prevState, nextState react.State) bool {
-	res := false
-
-	{{if .HasProps -}}
-	{
-	{{if .PropsHasEquals -}}
-	res = !{{.Recv}}.Props().Equals(nextProps.({{.Name}}Props)) || res
-	{{else -}}
-	res = {{.Recv}}.Props() != nextProps.({{.Name}}Props) || res
-	{{end -}}
-	}
-	{{end -}}
-	{{if .HasState -}}
-	v := prevState.({{.Name}}State)
-	res = !v.EqualsIntf(nextState) || res
-	{{end -}}
-
-	return res
-}
-
 func build{{.Name}}(cd react.ComponentDef) react.Component {
 	return {{.Name}}Def{ComponentDef: cd}
 }

--- a/components/imm/gen_Select_reactGen.go
+++ b/components/imm/gen_Select_reactGen.go
@@ -8,17 +8,6 @@ type SelectElem struct {
 	react.Element
 }
 
-func (s SelectDef) ShouldComponentUpdateIntf(nextProps react.Props, prevState, nextState react.State) bool {
-	res := false
-
-	{
-		res = s.Props() != nextProps.(SelectProps) || res
-	}
-	v := prevState.(SelectState)
-	res = !v.EqualsIntf(nextState) || res
-	return res
-}
-
 func buildSelect(cd react.ComponentDef) react.Component {
 	return SelectDef{ComponentDef: cd}
 }

--- a/examples/blog/2017_04_16/gen_App_reactGen.go
+++ b/examples/blog/2017_04_16/gen_App_reactGen.go
@@ -8,12 +8,6 @@ type AppElem struct {
 	react.Element
 }
 
-func (a AppDef) ShouldComponentUpdateIntf(nextProps react.Props, prevState, nextState react.State) bool {
-	res := false
-
-	return res
-}
-
 func buildApp(cd react.ComponentDef) react.Component {
 	return AppDef{ComponentDef: cd}
 }

--- a/examples/blog/2017_04_16/gen_FooBar_reactGen.go
+++ b/examples/blog/2017_04_16/gen_FooBar_reactGen.go
@@ -8,17 +8,6 @@ type FooBarElem struct {
 	react.Element
 }
 
-func (f FooBarDef) ShouldComponentUpdateIntf(nextProps react.Props, prevState, nextState react.State) bool {
-	res := false
-
-	{
-		res = f.Props() != nextProps.(FooBarProps) || res
-	}
-	v := prevState.(FooBarState)
-	res = !v.EqualsIntf(nextState) || res
-	return res
-}
-
 func buildFooBar(cd react.ComponentDef) react.Component {
 	return FooBarDef{ComponentDef: cd}
 }

--- a/examples/gen_Examples_reactGen.go
+++ b/examples/gen_Examples_reactGen.go
@@ -8,14 +8,6 @@ type ExamplesElem struct {
 	react.Element
 }
 
-func (e ExamplesDef) ShouldComponentUpdateIntf(nextProps react.Props, prevState, nextState react.State) bool {
-	res := false
-
-	v := prevState.(ExamplesState)
-	res = !v.EqualsIntf(nextState) || res
-	return res
-}
-
 func buildExamples(cd react.ComponentDef) react.Component {
 	return ExamplesDef{ComponentDef: cd}
 }

--- a/examples/gen_GlobalStateExamples_reactGen.go
+++ b/examples/gen_GlobalStateExamples_reactGen.go
@@ -8,14 +8,6 @@ type GlobalStateExamplesElem struct {
 	react.Element
 }
 
-func (g GlobalStateExamplesDef) ShouldComponentUpdateIntf(nextProps react.Props, prevState, nextState react.State) bool {
-	res := false
-
-	v := prevState.(GlobalStateExamplesState)
-	res = !v.EqualsIntf(nextState) || res
-	return res
-}
-
 func buildGlobalStateExamples(cd react.ComponentDef) react.Component {
 	return GlobalStateExamplesDef{ComponentDef: cd}
 }

--- a/examples/gen_ImmExamples_reactGen.go
+++ b/examples/gen_ImmExamples_reactGen.go
@@ -8,14 +8,6 @@ type ImmExamplesElem struct {
 	react.Element
 }
 
-func (i ImmExamplesDef) ShouldComponentUpdateIntf(nextProps react.Props, prevState, nextState react.State) bool {
-	res := false
-
-	v := prevState.(ImmExamplesState)
-	res = !v.EqualsIntf(nextState) || res
-	return res
-}
-
 func buildImmExamples(cd react.ComponentDef) react.Component {
 	return ImmExamplesDef{ComponentDef: cd}
 }

--- a/examples/hellomessage/gen_HelloMessage_reactGen.go
+++ b/examples/hellomessage/gen_HelloMessage_reactGen.go
@@ -8,15 +8,6 @@ type HelloMessageElem struct {
 	react.Element
 }
 
-func (h HelloMessageDef) ShouldComponentUpdateIntf(nextProps react.Props, prevState, nextState react.State) bool {
-	res := false
-
-	{
-		res = h.Props() != nextProps.(HelloMessageProps) || res
-	}
-	return res
-}
-
 func buildHelloMessage(cd react.ComponentDef) react.Component {
 	return HelloMessageDef{ComponentDef: cd}
 }

--- a/examples/immtodoapp/gen_TodoApp_reactGen.go
+++ b/examples/immtodoapp/gen_TodoApp_reactGen.go
@@ -8,14 +8,6 @@ type TodoAppElem struct {
 	react.Element
 }
 
-func (t TodoAppDef) ShouldComponentUpdateIntf(nextProps react.Props, prevState, nextState react.State) bool {
-	res := false
-
-	v := prevState.(TodoAppState)
-	res = !v.EqualsIntf(nextState) || res
-	return res
-}
-
 func buildTodoApp(cd react.ComponentDef) react.Component {
 	return TodoAppDef{ComponentDef: cd}
 }

--- a/examples/markdowneditor/gen_MarkdownEditor_reactGen.go
+++ b/examples/markdowneditor/gen_MarkdownEditor_reactGen.go
@@ -8,14 +8,6 @@ type MarkdownEditorElem struct {
 	react.Element
 }
 
-func (m MarkdownEditorDef) ShouldComponentUpdateIntf(nextProps react.Props, prevState, nextState react.State) bool {
-	res := false
-
-	v := prevState.(MarkdownEditorState)
-	res = !v.EqualsIntf(nextState) || res
-	return res
-}
-
 func buildMarkdownEditor(cd react.ComponentDef) react.Component {
 	return MarkdownEditorDef{ComponentDef: cd}
 }

--- a/examples/sites/examplesshowcase/gen_App_reactGen.go
+++ b/examples/sites/examplesshowcase/gen_App_reactGen.go
@@ -8,14 +8,6 @@ type AppElem struct {
 	react.Element
 }
 
-func (a AppDef) ShouldComponentUpdateIntf(nextProps react.Props, prevState, nextState react.State) bool {
-	res := false
-
-	v := prevState.(AppState)
-	res = !v.EqualsIntf(nextState) || res
-	return res
-}
-
 func buildApp(cd react.ComponentDef) react.Component {
 	return AppDef{ComponentDef: cd}
 }

--- a/examples/sites/globalstate/gen_App_reactGen.go
+++ b/examples/sites/globalstate/gen_App_reactGen.go
@@ -8,14 +8,6 @@ type AppElem struct {
 	react.Element
 }
 
-func (a AppDef) ShouldComponentUpdateIntf(nextProps react.Props, prevState, nextState react.State) bool {
-	res := false
-
-	v := prevState.(AppState)
-	res = !v.EqualsIntf(nextState) || res
-	return res
-}
-
 func buildApp(cd react.ComponentDef) react.Component {
 	return AppDef{ComponentDef: cd}
 }

--- a/examples/sites/globalstate/gen_PersonChooser_reactGen.go
+++ b/examples/sites/globalstate/gen_PersonChooser_reactGen.go
@@ -8,17 +8,6 @@ type PersonChooserElem struct {
 	react.Element
 }
 
-func (p PersonChooserDef) ShouldComponentUpdateIntf(nextProps react.Props, prevState, nextState react.State) bool {
-	res := false
-
-	{
-		res = p.Props() != nextProps.(PersonChooserProps) || res
-	}
-	v := prevState.(PersonChooserState)
-	res = !v.EqualsIntf(nextState) || res
-	return res
-}
-
 func buildPersonChooser(cd react.ComponentDef) react.Component {
 	return PersonChooserDef{ComponentDef: cd}
 }

--- a/examples/sites/globalstate/gen_PersonViewer_reactGen.go
+++ b/examples/sites/globalstate/gen_PersonViewer_reactGen.go
@@ -8,14 +8,6 @@ type PersonViewerElem struct {
 	react.Element
 }
 
-func (p PersonViewerDef) ShouldComponentUpdateIntf(nextProps react.Props, prevState, nextState react.State) bool {
-	res := false
-
-	v := prevState.(PersonViewerState)
-	res = !v.EqualsIntf(nextState) || res
-	return res
-}
-
 func buildPersonViewer(cd react.ComponentDef) react.Component {
 	return PersonViewerDef{ComponentDef: cd}
 }

--- a/examples/sites/helloworld/gen_App_reactGen.go
+++ b/examples/sites/helloworld/gen_App_reactGen.go
@@ -8,12 +8,6 @@ type AppElem struct {
 	react.Element
 }
 
-func (a AppDef) ShouldComponentUpdateIntf(nextProps react.Props, prevState, nextState react.State) bool {
-	res := false
-
-	return res
-}
-
 func buildApp(cd react.ComponentDef) react.Component {
 	return AppDef{ComponentDef: cd}
 }

--- a/examples/sites/helloworldbootstrap/gen_App_reactGen.go
+++ b/examples/sites/helloworldbootstrap/gen_App_reactGen.go
@@ -8,12 +8,6 @@ type AppElem struct {
 	react.Element
 }
 
-func (a AppDef) ShouldComponentUpdateIntf(nextProps react.Props, prevState, nextState react.State) bool {
-	res := false
-
-	return res
-}
-
 func buildApp(cd react.ComponentDef) react.Component {
 	return AppDef{ComponentDef: cd}
 }

--- a/examples/sites/latency/gen_App_reactGen.go
+++ b/examples/sites/latency/gen_App_reactGen.go
@@ -8,12 +8,6 @@ type AppElem struct {
 	react.Element
 }
 
-func (a AppDef) ShouldComponentUpdateIntf(nextProps react.Props, prevState, nextState react.State) bool {
-	res := false
-
-	return res
-}
-
 func buildApp(cd react.ComponentDef) react.Component {
 	return AppDef{ComponentDef: cd}
 }

--- a/examples/sites/latency/gen_Latency_reactGen.go
+++ b/examples/sites/latency/gen_Latency_reactGen.go
@@ -8,14 +8,6 @@ type LatencyElem struct {
 	react.Element
 }
 
-func (l LatencyDef) ShouldComponentUpdateIntf(nextProps react.Props, prevState, nextState react.State) bool {
-	res := false
-
-	v := prevState.(LatencyState)
-	res = !v.EqualsIntf(nextState) || res
-	return res
-}
-
 func buildLatency(cd react.ComponentDef) react.Component {
 	return LatencyDef{ComponentDef: cd}
 }

--- a/examples/sites/present/gen_App_reactGen.go
+++ b/examples/sites/present/gen_App_reactGen.go
@@ -8,14 +8,6 @@ type AppElem struct {
 	react.Element
 }
 
-func (a AppDef) ShouldComponentUpdateIntf(nextProps react.Props, prevState, nextState react.State) bool {
-	res := false
-
-	v := prevState.(AppState)
-	res = !v.EqualsIntf(nextState) || res
-	return res
-}
-
 func buildApp(cd react.ComponentDef) react.Component {
 	return AppDef{ComponentDef: cd}
 }

--- a/examples/timer/gen_Timer_reactGen.go
+++ b/examples/timer/gen_Timer_reactGen.go
@@ -8,14 +8,6 @@ type TimerElem struct {
 	react.Element
 }
 
-func (t TimerDef) ShouldComponentUpdateIntf(nextProps react.Props, prevState, nextState react.State) bool {
-	res := false
-
-	v := prevState.(TimerState)
-	res = !v.EqualsIntf(nextState) || res
-	return res
-}
-
 func buildTimer(cd react.ComponentDef) react.Component {
 	return TimerDef{ComponentDef: cd}
 }

--- a/examples/todoapp/gen_TodoApp_reactGen.go
+++ b/examples/todoapp/gen_TodoApp_reactGen.go
@@ -8,14 +8,6 @@ type TodoAppElem struct {
 	react.Element
 }
 
-func (t TodoAppDef) ShouldComponentUpdateIntf(nextProps react.Props, prevState, nextState react.State) bool {
-	res := false
-
-	v := prevState.(TodoAppState)
-	res = !v.EqualsIntf(nextState) || res
-	return res
-}
-
 func buildTodoApp(cd react.ComponentDef) react.Component {
 	return TodoAppDef{ComponentDef: cd}
 }

--- a/testutils/gen_Wrapper_reactGen.go
+++ b/testutils/gen_Wrapper_reactGen.go
@@ -8,12 +8,6 @@ type WrapperElem struct {
 	react.Element
 }
 
-func (w WrapperDef) ShouldComponentUpdateIntf(nextProps react.Props, prevState, nextState react.State) bool {
-	res := false
-
-	return res
-}
-
 func buildWrapper(cd react.ComponentDef) react.Component {
 	return WrapperDef{ComponentDef: cd}
 }


### PR DESCRIPTION
React's `setState` is asynchronous. Per [the wiki](https://github.com/myitcv/react/wiki/Gotchas#setstate-updates-state-synchronously) we have deliberately taken the decision to make it synchronous in `myitcv.io/react`

Previously we used the "underlying" `setState` in order to trigger a re-render when the state has changed (as determined by a comparison of state values, or an equals method if one exists on the state). 

But we can actually be slightly more specific and use `forceUpdate`.

Which in turn means the `shouldComponentUpdate` is entirely a function of whether the props are equal (again as determined by comparing props values, or an equals method if one exists)