### PR TITLE
Tidy up present license and links

### DIFF
--- a/examples/sites/present/README.md
+++ b/examples/sites/present/README.md
@@ -2,4 +2,14 @@
 
 A very very rough first cut of present running as a GopherJS app.
 
-Uses a rough copy and paste of much of the `present` command code - license and credits to follow...
+Uses largely a copy-paste of much of the [original `present` command](https://godoc.org/golang.org/x/tools/cmd/present).
+
+### Hosted version
+
+A hosted version of this program can be found here:
+
+http://blog.myitcv.io/gopherjs_examples_sites/present/
+
+My [GolangUK 2017 talk
+slides](http://blog.myitcv.io/gopherjs_examples_sites/present/?url=https://raw.githubusercontent.com/myitcv/react/master/_talks/2017/golang_uk.slide&hideAddressBar=true)
+give a good example of some actual slides loaded within the program.

--- a/examples/sites/present/dir.go
+++ b/examples/sites/present/dir.go
@@ -1,3 +1,11 @@
+// Copyright (c) 2018 Paul Jolly <paul@myitcv.org.uk>, all rights reserved.
+// Use of this document is governed by a license found in the LICENSE document.
+
+// This package contains a fair amount of copy-paste from
+// https://godoc.org/golang.org/x/tools/cmd/present.  The copyright notice from
+// that repo can be seen below, and is linked
+// https://github.com/golang/tools/blob/master/LICENSE
+
 // Copyright 2012 The Go Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.


### PR DESCRIPTION
Make sure we properly link to the original present code.