### PR TITLE
Remove generic definition of aria-* attributes

### DIFF
--- a/core.go
+++ b/core.go
@@ -23,7 +23,6 @@ func newBasicElement() *BasicElement {
 }
 
 type DataSet map[string]string
-type AriaSet map[string]string
 
 type BasicHTMLElement struct {
 	*BasicElement
@@ -35,7 +34,6 @@ type BasicHTMLElement struct {
 	Style     *CSS   `js:"style"`
 
 	DataSet
-	AriaSet
 
 	OnChange `js:"onChange"`
 	OnClick  `js:"onClick"`

--- a/gen_AProps_reactGen.go
+++ b/gen_AProps_reactGen.go
@@ -4,7 +4,6 @@ package react
 
 // AProps defines the properties for the <a> element
 type AProps struct {
-	AriaSet
 	ClassName               string
 	DangerouslySetInnerHTML *DangerousInnerHTML
 	DataSet
@@ -23,12 +22,6 @@ type AProps struct {
 }
 
 func (a *AProps) assign(v *_AProps) {
-
-	if a.AriaSet != nil {
-		for dk, dv := range a.AriaSet {
-			v.o.Set("aria-"+dk, dv)
-		}
-	}
 
 	v.ClassName = a.ClassName
 

--- a/gen_BrProps_reactGen.go
+++ b/gen_BrProps_reactGen.go
@@ -4,7 +4,6 @@ package react
 
 // BrProps defines the properties for the <br> element
 type BrProps struct {
-	AriaSet
 	ClassName               string
 	DangerouslySetInnerHTML *DangerousInnerHTML
 	DataSet
@@ -20,12 +19,6 @@ type BrProps struct {
 }
 
 func (b *BrProps) assign(v *_BrProps) {
-
-	if b.AriaSet != nil {
-		for dk, dv := range b.AriaSet {
-			v.o.Set("aria-"+dk, dv)
-		}
-	}
 
 	v.ClassName = b.ClassName
 

--- a/gen_ButtonProps_reactGen.go
+++ b/gen_ButtonProps_reactGen.go
@@ -4,7 +4,6 @@ package react
 
 // ButtonProps defines the properties for the <button> element
 type ButtonProps struct {
-	AriaSet
 	ClassName               string
 	DangerouslySetInnerHTML *DangerousInnerHTML
 	DataSet
@@ -21,12 +20,6 @@ type ButtonProps struct {
 }
 
 func (b *ButtonProps) assign(v *_ButtonProps) {
-
-	if b.AriaSet != nil {
-		for dk, dv := range b.AriaSet {
-			v.o.Set("aria-"+dk, dv)
-		}
-	}
 
 	v.ClassName = b.ClassName
 

--- a/gen_CodeProps_reactGen.go
+++ b/gen_CodeProps_reactGen.go
@@ -4,7 +4,6 @@ package react
 
 // CodeProps defines the properties for the <code> element
 type CodeProps struct {
-	AriaSet
 	ClassName               string
 	DangerouslySetInnerHTML *DangerousInnerHTML
 	DataSet
@@ -20,12 +19,6 @@ type CodeProps struct {
 }
 
 func (c *CodeProps) assign(v *_CodeProps) {
-
-	if c.AriaSet != nil {
-		for dk, dv := range c.AriaSet {
-			v.o.Set("aria-"+dk, dv)
-		}
-	}
 
 	v.ClassName = c.ClassName
 

--- a/gen_DivProps_reactGen.go
+++ b/gen_DivProps_reactGen.go
@@ -4,7 +4,6 @@ package react
 
 // DivProps are the props for a <div> component
 type DivProps struct {
-	AriaSet
 	ClassName               string
 	DangerouslySetInnerHTML *DangerousInnerHTML
 	DataSet
@@ -20,12 +19,6 @@ type DivProps struct {
 }
 
 func (d *DivProps) assign(v *_DivProps) {
-
-	if d.AriaSet != nil {
-		for dk, dv := range d.AriaSet {
-			v.o.Set("aria-"+dk, dv)
-		}
-	}
 
 	v.ClassName = d.ClassName
 

--- a/gen_FooterProps_reactGen.go
+++ b/gen_FooterProps_reactGen.go
@@ -4,7 +4,6 @@ package react
 
 // FooterProps are the props for a <footer> component
 type FooterProps struct {
-	AriaSet
 	ClassName               string
 	DangerouslySetInnerHTML *DangerousInnerHTML
 	DataSet
@@ -20,12 +19,6 @@ type FooterProps struct {
 }
 
 func (f *FooterProps) assign(v *_FooterProps) {
-
-	if f.AriaSet != nil {
-		for dk, dv := range f.AriaSet {
-			v.o.Set("aria-"+dk, dv)
-		}
-	}
 
 	v.ClassName = f.ClassName
 

--- a/gen_FormProps_reactGen.go
+++ b/gen_FormProps_reactGen.go
@@ -4,7 +4,6 @@ package react
 
 // FormProps defines the properties for the <form> element
 type FormProps struct {
-	AriaSet
 	ClassName               string
 	DangerouslySetInnerHTML *DangerousInnerHTML
 	DataSet
@@ -20,12 +19,6 @@ type FormProps struct {
 }
 
 func (f *FormProps) assign(v *_FormProps) {
-
-	if f.AriaSet != nil {
-		for dk, dv := range f.AriaSet {
-			v.o.Set("aria-"+dk, dv)
-		}
-	}
 
 	v.ClassName = f.ClassName
 

--- a/gen_H1Props_reactGen.go
+++ b/gen_H1Props_reactGen.go
@@ -4,7 +4,6 @@ package react
 
 // H1Props defines the properties for the <h1> element
 type H1Props struct {
-	AriaSet
 	ClassName               string
 	DangerouslySetInnerHTML *DangerousInnerHTML
 	DataSet
@@ -20,12 +19,6 @@ type H1Props struct {
 }
 
 func (h *H1Props) assign(v *_H1Props) {
-
-	if h.AriaSet != nil {
-		for dk, dv := range h.AriaSet {
-			v.o.Set("aria-"+dk, dv)
-		}
-	}
 
 	v.ClassName = h.ClassName
 

--- a/gen_H3Props_reactGen.go
+++ b/gen_H3Props_reactGen.go
@@ -4,7 +4,6 @@ package react
 
 // H3Props defines the properties for the <h3> element
 type H3Props struct {
-	AriaSet
 	ClassName               string
 	DangerouslySetInnerHTML *DangerousInnerHTML
 	DataSet
@@ -20,12 +19,6 @@ type H3Props struct {
 }
 
 func (h *H3Props) assign(v *_H3Props) {
-
-	if h.AriaSet != nil {
-		for dk, dv := range h.AriaSet {
-			v.o.Set("aria-"+dk, dv)
-		}
-	}
 
 	v.ClassName = h.ClassName
 

--- a/gen_H4Props_reactGen.go
+++ b/gen_H4Props_reactGen.go
@@ -4,7 +4,6 @@ package react
 
 // H4Props defines the properties for the <h4> element
 type H4Props struct {
-	AriaSet
 	ClassName               string
 	DangerouslySetInnerHTML *DangerousInnerHTML
 	DataSet
@@ -20,12 +19,6 @@ type H4Props struct {
 }
 
 func (h *H4Props) assign(v *_H4Props) {
-
-	if h.AriaSet != nil {
-		for dk, dv := range h.AriaSet {
-			v.o.Set("aria-"+dk, dv)
-		}
-	}
 
 	v.ClassName = h.ClassName
 

--- a/gen_HrProps_reactGen.go
+++ b/gen_HrProps_reactGen.go
@@ -4,7 +4,6 @@ package react
 
 // HrProps defines the properties for the <hr> element
 type HrProps struct {
-	AriaSet
 	ClassName               string
 	DangerouslySetInnerHTML *DangerousInnerHTML
 	DataSet
@@ -20,12 +19,6 @@ type HrProps struct {
 }
 
 func (h *HrProps) assign(v *_HrProps) {
-
-	if h.AriaSet != nil {
-		for dk, dv := range h.AriaSet {
-			v.o.Set("aria-"+dk, dv)
-		}
-	}
 
 	v.ClassName = h.ClassName
 

--- a/gen_IFrameProps_reactGen.go
+++ b/gen_IFrameProps_reactGen.go
@@ -4,7 +4,6 @@ package react
 
 // IFrameProps are the props for a <iframe> component
 type IFrameProps struct {
-	AriaSet
 	ClassName               string
 	DangerouslySetInnerHTML *DangerousInnerHTML
 	DataSet
@@ -22,12 +21,6 @@ type IFrameProps struct {
 }
 
 func (i *IFrameProps) assign(v *_IFrameProps) {
-
-	if i.AriaSet != nil {
-		for dk, dv := range i.AriaSet {
-			v.o.Set("aria-"+dk, dv)
-		}
-	}
 
 	v.ClassName = i.ClassName
 

--- a/gen_IProps_reactGen.go
+++ b/gen_IProps_reactGen.go
@@ -4,7 +4,6 @@ package react
 
 // IProps are the props for a <i> component
 type IProps struct {
-	AriaSet
 	ClassName               string
 	DangerouslySetInnerHTML *DangerousInnerHTML
 	DataSet
@@ -21,12 +20,6 @@ type IProps struct {
 }
 
 func (i *IProps) assign(v *_IProps) {
-
-	if i.AriaSet != nil {
-		for dk, dv := range i.AriaSet {
-			v.o.Set("aria-"+dk, dv)
-		}
-	}
 
 	v.ClassName = i.ClassName
 

--- a/gen_ImgProps_reactGen.go
+++ b/gen_ImgProps_reactGen.go
@@ -4,8 +4,7 @@ package react
 
 // ImgProps are the props for a <Img> component
 type ImgProps struct {
-	Alt string
-	AriaSet
+	Alt                     string
 	ClassName               string
 	DangerouslySetInnerHTML *DangerousInnerHTML
 	DataSet
@@ -24,12 +23,6 @@ type ImgProps struct {
 func (i *ImgProps) assign(v *_ImgProps) {
 
 	v.Alt = i.Alt
-
-	if i.AriaSet != nil {
-		for dk, dv := range i.AriaSet {
-			v.o.Set("aria-"+dk, dv)
-		}
-	}
 
 	v.ClassName = i.ClassName
 

--- a/gen_InputProps_reactGen.go
+++ b/gen_InputProps_reactGen.go
@@ -4,7 +4,6 @@ package react
 
 // InputProps defines the properties for the <input> element
 type InputProps struct {
-	AriaSet
 	ClassName               string
 	DangerouslySetInnerHTML *DangerousInnerHTML
 	DataSet
@@ -24,12 +23,6 @@ type InputProps struct {
 }
 
 func (i *InputProps) assign(v *_InputProps) {
-
-	if i.AriaSet != nil {
-		for dk, dv := range i.AriaSet {
-			v.o.Set("aria-"+dk, dv)
-		}
-	}
 
 	v.ClassName = i.ClassName
 

--- a/gen_LabelProps_reactGen.go
+++ b/gen_LabelProps_reactGen.go
@@ -4,7 +4,6 @@ package react
 
 // LabelProps defines the properties for the <label> element
 type LabelProps struct {
-	AriaSet
 	ClassName               string
 	DangerouslySetInnerHTML *DangerousInnerHTML
 	DataSet
@@ -21,12 +20,6 @@ type LabelProps struct {
 }
 
 func (l *LabelProps) assign(v *_LabelProps) {
-
-	if l.AriaSet != nil {
-		for dk, dv := range l.AriaSet {
-			v.o.Set("aria-"+dk, dv)
-		}
-	}
 
 	v.ClassName = l.ClassName
 

--- a/gen_LiProps_reactGen.go
+++ b/gen_LiProps_reactGen.go
@@ -4,7 +4,6 @@ package react
 
 // LiProps defines the properties for the <li> element
 type LiProps struct {
-	AriaSet
 	ClassName               string
 	DangerouslySetInnerHTML *DangerousInnerHTML
 	DataSet
@@ -20,12 +19,6 @@ type LiProps struct {
 }
 
 func (l *LiProps) assign(v *_LiProps) {
-
-	if l.AriaSet != nil {
-		for dk, dv := range l.AriaSet {
-			v.o.Set("aria-"+dk, dv)
-		}
-	}
 
 	v.ClassName = l.ClassName
 

--- a/gen_NavProps_reactGen.go
+++ b/gen_NavProps_reactGen.go
@@ -4,7 +4,6 @@ package react
 
 // NavProps defines the properties for the <nav> element
 type NavProps struct {
-	AriaSet
 	ClassName               string
 	DangerouslySetInnerHTML *DangerousInnerHTML
 	DataSet
@@ -20,12 +19,6 @@ type NavProps struct {
 }
 
 func (n *NavProps) assign(v *_NavProps) {
-
-	if n.AriaSet != nil {
-		for dk, dv := range n.AriaSet {
-			v.o.Set("aria-"+dk, dv)
-		}
-	}
 
 	v.ClassName = n.ClassName
 

--- a/gen_OptionProps_reactGen.go
+++ b/gen_OptionProps_reactGen.go
@@ -4,7 +4,6 @@ package react
 
 // OptionProps defines the properties for the <option> element
 type OptionProps struct {
-	AriaSet
 	ClassName               string
 	DangerouslySetInnerHTML *DangerousInnerHTML
 	DataSet
@@ -21,12 +20,6 @@ type OptionProps struct {
 }
 
 func (o *OptionProps) assign(v *_OptionProps) {
-
-	if o.AriaSet != nil {
-		for dk, dv := range o.AriaSet {
-			v.o.Set("aria-"+dk, dv)
-		}
-	}
 
 	v.ClassName = o.ClassName
 

--- a/gen_PProps_reactGen.go
+++ b/gen_PProps_reactGen.go
@@ -4,7 +4,6 @@ package react
 
 // PProps are the props for a <div> component
 type PProps struct {
-	AriaSet
 	ClassName               string
 	DangerouslySetInnerHTML *DangerousInnerHTML
 	DataSet
@@ -20,12 +19,6 @@ type PProps struct {
 }
 
 func (p *PProps) assign(v *_PProps) {
-
-	if p.AriaSet != nil {
-		for dk, dv := range p.AriaSet {
-			v.o.Set("aria-"+dk, dv)
-		}
-	}
 
 	v.ClassName = p.ClassName
 

--- a/gen_PreProps_reactGen.go
+++ b/gen_PreProps_reactGen.go
@@ -4,7 +4,6 @@ package react
 
 // PreProps defines the properties for the <pre> element
 type PreProps struct {
-	AriaSet
 	ClassName               string
 	DangerouslySetInnerHTML *DangerousInnerHTML
 	DataSet
@@ -20,12 +19,6 @@ type PreProps struct {
 }
 
 func (p *PreProps) assign(v *_PreProps) {
-
-	if p.AriaSet != nil {
-		for dk, dv := range p.AriaSet {
-			v.o.Set("aria-"+dk, dv)
-		}
-	}
 
 	v.ClassName = p.ClassName
 

--- a/gen_SelectProps_reactGen.go
+++ b/gen_SelectProps_reactGen.go
@@ -4,7 +4,6 @@ package react
 
 // SelectProps are the props for a <select> component
 type SelectProps struct {
-	AriaSet
 	ClassName               string
 	DangerouslySetInnerHTML *DangerousInnerHTML
 	DataSet
@@ -21,12 +20,6 @@ type SelectProps struct {
 }
 
 func (s *SelectProps) assign(v *_SelectProps) {
-
-	if s.AriaSet != nil {
-		for dk, dv := range s.AriaSet {
-			v.o.Set("aria-"+dk, dv)
-		}
-	}
 
 	v.ClassName = s.ClassName
 

--- a/gen_SpanProps_reactGen.go
+++ b/gen_SpanProps_reactGen.go
@@ -4,7 +4,6 @@ package react
 
 // SpanProps defines the properties for the <p> element
 type SpanProps struct {
-	AriaSet
 	ClassName               string
 	DangerouslySetInnerHTML *DangerousInnerHTML
 	DataSet
@@ -20,12 +19,6 @@ type SpanProps struct {
 }
 
 func (s *SpanProps) assign(v *_SpanProps) {
-
-	if s.AriaSet != nil {
-		for dk, dv := range s.AriaSet {
-			v.o.Set("aria-"+dk, dv)
-		}
-	}
 
 	v.ClassName = s.ClassName
 

--- a/gen_TableProps_reactGen.go
+++ b/gen_TableProps_reactGen.go
@@ -4,7 +4,6 @@ package react
 
 // TableProps are the props for a <table> component
 type TableProps struct {
-	AriaSet
 	ClassName               string
 	DangerouslySetInnerHTML *DangerousInnerHTML
 	DataSet
@@ -20,12 +19,6 @@ type TableProps struct {
 }
 
 func (t *TableProps) assign(v *_TableProps) {
-
-	if t.AriaSet != nil {
-		for dk, dv := range t.AriaSet {
-			v.o.Set("aria-"+dk, dv)
-		}
-	}
 
 	v.ClassName = t.ClassName
 

--- a/gen_TextAreaProps_reactGen.go
+++ b/gen_TextAreaProps_reactGen.go
@@ -4,7 +4,6 @@ package react
 
 // TextAreaProps defines the properties for the <textarea> element
 type TextAreaProps struct {
-	AriaSet
 	ClassName               string
 	Cols                    uint
 	DangerouslySetInnerHTML *DangerousInnerHTML
@@ -25,12 +24,6 @@ type TextAreaProps struct {
 }
 
 func (t *TextAreaProps) assign(v *_TextAreaProps) {
-
-	if t.AriaSet != nil {
-		for dk, dv := range t.AriaSet {
-			v.o.Set("aria-"+dk, dv)
-		}
-	}
 
 	v.ClassName = t.ClassName
 

--- a/gen_UlProps_reactGen.go
+++ b/gen_UlProps_reactGen.go
@@ -4,7 +4,6 @@ package react
 
 // UlProps defines the properties for the <ul> element
 type UlProps struct {
-	AriaSet
 	ClassName               string
 	DangerouslySetInnerHTML *DangerousInnerHTML
 	DataSet
@@ -20,12 +19,6 @@ type UlProps struct {
 }
 
 func (u *UlProps) assign(v *_UlProps) {
-
-	if u.AriaSet != nil {
-		for dk, dv := range u.AriaSet {
-			v.o.Set("aria-"+dk, dv)
-		}
-	}
 
 	v.ClassName = u.ClassName
 

--- a/jsx/jsx.go
+++ b/jsx/jsx.go
@@ -68,7 +68,6 @@ func parseSpan(n *html.Node) *react.SpanElem {
 
 	var vp *react.SpanProps
 	var ds react.DataSet
-	var as react.AriaSet
 
 	if len(n.Attr) > 0 {
 		vp = new(react.SpanProps)
@@ -79,12 +78,6 @@ func parseSpan(n *html.Node) *react.SpanElem {
 				vp.ClassName = a.Val
 			case v == "style":
 				vp.Style = parseCSS(a.Val)
-			case strings.HasPrefix(v, "aria-"):
-				if as == nil {
-					as = make(react.AriaSet)
-				}
-
-				as[strings.TrimPrefix(v, "aria-")] = a.Val
 			case strings.HasPrefix(v, "data-"):
 				if ds == nil {
 					ds = make(react.DataSet)
@@ -102,7 +95,6 @@ func parseSpan(n *html.Node) *react.SpanElem {
 	}
 
 	vp.DataSet = ds
-	vp.AriaSet = as
 
 	return react.Span(vp, kids...)
 }
@@ -255,7 +247,6 @@ func parseImg(n *html.Node) *react.ImgElem {
 
 	var vp *react.ImgProps
 	var ds react.DataSet
-	var as react.AriaSet
 
 	if len(n.Attr) > 0 {
 		vp = new(react.ImgProps)
@@ -270,12 +261,6 @@ func parseImg(n *html.Node) *react.ImgElem {
 				vp.Style = parseCSS(a.Val)
 			case v == "alt":
 				vp.Alt = a.Val
-			case strings.HasPrefix(v, "aria-"):
-				if as == nil {
-					as = make(react.AriaSet)
-				}
-
-				as[strings.TrimPrefix(v, "aria-")] = a.Val
 			case strings.HasPrefix(v, "data-"):
 				if ds == nil {
 					ds = make(react.DataSet)
@@ -293,7 +278,6 @@ func parseImg(n *html.Node) *react.ImgElem {
 	}
 
 	vp.DataSet = ds
-	vp.AriaSet = as
 
 	return react.Img(vp, kids...)
 }


### PR DESCRIPTION
Aria attributes are well-defined, hence their definition here in `myitcv.io/react` should follow that definition:

https://www.w3.org/TR/wai-aria-1.1/#state_prop_def

Hence removing this generic `map[string]string` approach (which is correct for `data-*` attributes)